### PR TITLE
Fixes mingchen/django-cas-ng#17 "Forbidden in 3.4"

### DIFF
--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -30,7 +30,7 @@ def _service_url(request, redirect_to=None):
     protocol = get_protocol(request)
     host = request.get_host()
     service = urllib_parse.urlunparse(
-        (protocol, host, request.get_full_path(), '', '', ''),
+        (protocol, host, request.path, '', '', ''),
     )
     if redirect_to:
         if '?' in service:


### PR DESCRIPTION
Login service url had duplicated query string, e.g.,
http://host/login/?next=/path/to/app/&next=/path/to/app/
which resulted in 403 Forbidden error