### PR TITLE
Allow picking an alternative variable to store the username in the cas attributes

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -16,6 +16,7 @@ _DEFAULTS = {
     'CAS_RETRY_LOGIN': False,
     'CAS_SERVER_URL': None,
     'CAS_VERSION': '2',
+    'CAS_USERNAME_ATTRIBUTE': 'uid',
 }
 
 for key, value in _DEFAULTS.items():

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -201,9 +201,9 @@ def _verify_cas2_saml(ticket, service):
             # User is validated
             attrs = tree.findall('.//' + SAML_1_0_ASSERTION_NS + 'Attribute')
             for at in attrs:
-                if 'uid' in list(at.attrib.values()):
+                if settings.CAS_USERNAME_ATTRIBUTE in list(at.attrib.values()):
                     user = at.find(SAML_1_0_ASSERTION_NS + 'AttributeValue').text
-                    attributes['uid'] = user
+                    attributes[settings.CAS_USERNAME_ATTRIBUTE] = user
                     values = at.findall(SAML_1_0_ASSERTION_NS + 'AttributeValue')
                     if len(values) > 1:
                         values_array = []


### PR DESCRIPTION
Hi,
I am using a modified django-cas in a project, and there are a couple of patches we had to apply on the _verify_cas2_saml function. I think the changes would help everybody so maybe you are interested in merging them.

This first patch adds a new variable to store the name of the cas attribute that contains the username, so it can be changed from the settings.