### PR TITLE
Fix: allow to fill attributes variable in cas2saml

### DIFF
--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -204,14 +204,14 @@ def _verify_cas2_saml(ticket, service):
                 if 'uid' in list(at.attrib.values()):
                     user = at.find(SAML_1_0_ASSERTION_NS + 'AttributeValue').text
                     attributes['uid'] = user
-                    values = at.findall(SAML_1_0_ASSERTION_NS + 'AttributeValue')
-                    if len(values) > 1:
-                        values_array = []
-                        for v in values:
-                            values_array.append(v.text)
-                            attributes[at.attrib['AttributeName']] = values_array
-                    else:
-                        attributes[at.attrib['AttributeName']] = values[0].text
+                values = at.findall(SAML_1_0_ASSERTION_NS + 'AttributeValue')
+                if len(values) > 1:
+                    values_array = []
+                    for v in values:
+                        values_array.append(v.text)
+                        attributes[at.attrib['AttributeName']] = values_array
+                else:
+                    attributes[at.attrib['AttributeName']] = values[0].text
         return user, attributes
     finally:
         page.close()


### PR DESCRIPTION
Hi,

I think this is a bug in django-cas, maybe you can check it. With the current code the authenticate function always receives attributes variable from _verify with just one attribute: uid. This patch fixes the problem for me.