### PR TITLE
Fix: allow alternative status code for success in cas2saml

### DIFF
--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -197,7 +197,7 @@ def _verify_cas2_saml(ticket, service):
         tree = ElementTree.fromstring(response)
         # Find the authentication status
         success = tree.find('.//' + SAML_1_0_PROTOCOL_NS + 'StatusCode')
-        if success is not None and success.attrib['Value'] == 'samlp:Success':
+        if success is not None and success.attrib['Value'].endswith(':Success'):
             # User is validated
             attrs = tree.findall('.//' + SAML_1_0_ASSERTION_NS + 'Attribute')
             for at in attrs:


### PR DESCRIPTION
The cas I am using sends 'saml1p:Success' instead of 'samlp:Success'. I don't know how many more possibilities are, but I think checking for a string ending in ':Success' should be safe.