### PR TITLE
Python 3 compatibility changes via modernize

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -1,5 +1,6 @@
 """Django CAS 1.0/2.0 authentication backend"""
 
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from django.conf import settings
@@ -19,7 +20,7 @@ _DEFAULTS = {
     'CAS_USERNAME_ATTRIBUTE': 'uid',
 }
 
-for key, value in _DEFAULTS.items():
+for key, value in list(_DEFAULTS.items()):
     try:
         getattr(settings, key)
     except AttributeError:

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -1,4 +1,5 @@
 """CAS authentication backend"""
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import datetime

--- a/django_cas_ng/decorators.py
+++ b/django_cas_ng/decorators.py
@@ -1,5 +1,6 @@
 """Replacement authentication decorators that work around redirection loops"""
 
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 try:

--- a/django_cas_ng/middleware.py
+++ b/django_cas_ng/middleware.py
@@ -1,5 +1,6 @@
 """CAS authentication middleware"""
 
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from django.utils.six.moves import urllib_parse

--- a/django_cas_ng/signals.py
+++ b/django_cas_ng/signals.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django import dispatch
 
 cas_user_authenticated = dispatch.Signal(

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -1,5 +1,6 @@
 """CAS login/logout replacement views"""
 
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from django.utils.six.moves import urllib_parse

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import absolute_import
 import sys
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+import codecs
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
-with open('README.rst') as f:
+with codecs.open('README.rst', encoding='utf-8') as f:
     readme = f.read()
 
 setup(

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import pytest
 
 from django.test import RequestFactory

--- a/tests/test_cas3_verification.py
+++ b/tests/test_cas3_verification.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django_cas_ng.backends import (
     verify_cas3_response,
 )

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import pytest
 
 from django.test import RequestFactory

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django_cas_ng.models import *
 from django_cas_ng.backends import *
 from django_cas_ng.middleware import *

--- a/tests/test_views_helpers.py
+++ b/tests/test_views_helpers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django.test import RequestFactory
 
 from django_cas_ng.views import (


### PR DESCRIPTION
Most of this was due to not being able to install the package in python3 due to unicode being in the README and my OS not having a default encoding set, but I went ahead and did what modernize told me as well.  I can pull back the other stuff, but the codec'd reading of the file is important for me to be able to install the package with python3.
