### PR TITLE
fix(backends): encode saml assertion to prevent TypeError on POST data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,8 @@ Credits
 * `timkung1`_.
 * `Domingo Yeray Rodríguez Martín`_.
 * `Rayco Abad-Martín`_.
-
+* `Édouard Lopez`_.
+* `Guillaume Vincent`_.
 
 References
 ----------

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -190,7 +190,8 @@ def _verify_cas2_saml(ticket, service):
         '',
         headers,
     )
-    page = urlopen(url, data=get_saml_assertion(ticket))
+    data = get_saml_assertion(ticket)
+    page = urlopen(url, data=data.encode('utf8'))
 
     try:
         user = None

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -170,28 +170,7 @@ def _verify_cas2_saml(ticket, service):
     except ImportError:
         from elementtree import ElementTree
 
-    # We do the SAML validation
-    headers = {
-        'soapaction': 'http://www.oasis-open.org/committees/security',
-        'cache-control': 'no-cache',
-        'pragma': 'no-cache',
-        'accept': 'text/xml',
-        'connection': 'keep-alive',
-        'content-type': 'text/xml; charset=utf-8',
-    }
-    params = [('TARGET', service)]
-
-    saml_validat_url = urllib_parse.urljoin(
-        settings.CAS_SERVER_URL, 'samlValidate',
-    )
-
-    url = Request(
-        saml_validat_url + '?' + urllib_parse.urlencode(params),
-        '',
-        headers,
-    )
-    data = get_saml_assertion(ticket)
-    page = urlopen(url, data=data.encode('utf8'))
+    page = fetch_saml_validation(service, ticket)
 
     try:
         user = None
@@ -219,6 +198,30 @@ def _verify_cas2_saml(ticket, service):
         return user, attributes
     finally:
         page.close()
+
+
+def fetch_saml_validation(service, ticket):
+    # We do the SAML validation
+    headers = {
+        'soapaction': 'http://www.oasis-open.org/committees/security',
+        'cache-control': 'no-cache',
+        'pragma': 'no-cache',
+        'accept': 'text/xml',
+        'connection': 'keep-alive',
+        'content-type': 'text/xml; charset=utf-8',
+    }
+    params = [('TARGET', service)]
+    saml_validat_url = urllib_parse.urljoin(
+        settings.CAS_SERVER_URL, 'samlValidate',
+    )
+    url = Request(
+        saml_validat_url + '?' + urllib_parse.urlencode(params),
+        '',
+        headers,
+    )
+    page = urlopen(url, data=get_saml_assertion(ticket))
+
+    return page
 
 
 _PROTOCOLS = {

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -148,7 +148,7 @@ def get_saml_assertion(ticket):
         request_id=request_id,
         timestamp=timestamp,
         ticket=ticket,
-    )
+    ).encode('utf8')
 
 
 SAML_1_0_NS = 'urn:oasis:names:tc:SAML:1.0:'

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
-import pytest
 
+import sys
+
+import pytest
 from django.test import RequestFactory
-from django_cas_ng.backends import CASBackend
+
+from django_cas_ng import backends
 
 
 @pytest.mark.django_db
@@ -27,7 +30,7 @@ def test_backend_authentication_creating_a_user(monkeypatch, django_user_model):
         username='test@example.com',
     ).exists()
 
-    backend = CASBackend()
+    backend = backends.CASBackend()
     user = backend.authenticate(
         ticket='fake-ticket', service='fake-service', request=request,
     )
@@ -58,7 +61,7 @@ def test_backend_for_existing_user(monkeypatch, django_user_model):
 
     existing_user = django_user_model.objects.create_user('test@example.com', '')
 
-    backend = CASBackend()
+    backend = backends.CASBackend()
     user = backend.authenticate(
         ticket='fake-ticket', service='fake-service', request=request,
     )
@@ -89,7 +92,7 @@ def test_backend_for_failed_auth(monkeypatch, django_user_model):
         username='test@example.com',
     ).exists()
 
-    backend = CASBackend()
+    backend = backends.CASBackend()
     user = backend.authenticate(
         ticket='fake-ticket', service='fake-service', request=request,
     )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -101,3 +101,15 @@ def test_backend_for_failed_auth(monkeypatch, django_user_model):
     assert not django_user_model.objects.filter(
         username='test@example.com',
     ).exists()
+
+
+def test_can_saml_assertion_is_encoded():
+    ticket = 'test-ticket'
+
+    saml = backends.get_saml_assertion(ticket)
+
+    if sys.version_info > (3, 0):
+        assert type(saml) is bytes
+        assert ticket.encode('utf-8') in saml
+    else:
+        assert ticket in saml


### PR DESCRIPTION
fixes #37 : TypeError at /accounts/login/ POST data should be bytes or an iterable of bytes. It cannot be of type str. 

