### PR TITLE
Store PGT on a per session basis

### DIFF
--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -14,8 +14,6 @@ from uuid import uuid4
 
 from django_cas_ng.signals import cas_user_authenticated
 
-from .models import ProxyGrantingTicket
-
 User = get_user_model()
 
 __all__ = ['CASBackend']
@@ -282,17 +280,7 @@ class CASBackend(ModelBackend):
             created = True
 
         if pgtiou and settings.CAS_PROXY_CALLBACK:
-            try:
-                pgt = ProxyGrantingTicket.objects.get(user=user)
-                pgt.delete()
-            except ProxyGrantingTicket.DoesNotExist:
-                pass
-            try:
-                pgt = ProxyGrantingTicket.objects.get(pgtiou=pgtiou)
-                pgt.user = user
-                pgt.save()
-            except ProxyGrantingTicket.DoesNotExist:
-                pass
+            request.session['pgtiou'] = pgtiou
 
         # send the `cas_user_authenticated` signal
         cas_user_authenticated.send(

--- a/django_cas_ng/models.py
+++ b/django_cas_ng/models.py
@@ -5,15 +5,24 @@ from django.contrib.auth.models import User
 from django.contrib.sessions.models import Session
 
 class ProxyGrantingTicket(models.Model):
+    class Meta:
+        unique_together = ('session', 'user')
+    session = models.ForeignKey(
+        Session,
+        related_name="+",
+        blank=True,
+        null=True
+    )
     user = models.ForeignKey(
         User,
         related_name="+",
-        unique=True,
         null=True,
         blank=True
     )
     pgtiou = models.CharField(max_length=255, null=True, blank=True)
     pgt = models.CharField(max_length=255, null=True, blank=True)
+    date = models.DateTimeField(auto_now_add=True, auto_now=True)
+
 
 class SessionTicket(models.Model):
     session = models.ForeignKey(Session, related_name="+", unique=True)

--- a/django_cas_ng/models.py
+++ b/django_cas_ng/models.py
@@ -1,9 +1,16 @@
 # Stub for pre django 1.7 apps.
 # ⁻*- coding: utf-8 -*-
 from django.db import models
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sessions.models import Session
 
+import urllib
+import urllib2
+from lxml import etree
+
+class ProxyError(ValueError):
+    pass
 class ProxyGrantingTicket(models.Model):
     class Meta:
         unique_together = ('session', 'user')
@@ -23,6 +30,42 @@ class ProxyGrantingTicket(models.Model):
     pgt = models.CharField(max_length=255, null=True, blank=True)
     date = models.DateTimeField(auto_now_add=True, auto_now=True)
 
+    @classmethod
+    def retrieve_pt(cls, request, service):
+        """`request` should be the current HttpRequest object
+        `service` a string representing the service for witch we want to
+        retrieve a ticket.
+        The function return a Proxy Ticket or raise `ProxyError`
+        """
+        session = Session.objects.get(session_key=request.session.session_key)
+        try:
+            pgt = cls.objects.get(user=request.user, session=session).pgt
+            params = urllib.urlencode({'pgt':pgt, 'targetService':service})
+            response = urllib2.urlopen(
+                "%s/proxy?%s" % (settings.CAS_SERVER_URL, params)
+            )
+            if response.code == 200:
+                root = etree.fromstring(response.read())
+                tickets = root.xpath(
+                    "//cas:proxyTicket",
+                    namespaces={"cas":"http://www.yale.edu/tp/cas"}
+                )
+                if len(tickets) == 1:
+                    return tickets[0].text
+                errors = root.xpath(
+                    "//cas:authenticationFailure",
+                    namespaces={"cas":"http://www.yale.edu/tp/cas"}
+                )
+                if len(errors) == 1:
+                    raise ProxyError(errors[0].attrib['code'], errors[0].text)
+            raise ProxyError("Bad http code %s" % response.code)
+        except urllib2.HTTPError as error:
+            raise ProxyError(str(error))
+        except cls.DoesNotExist:
+            raise ProxyError(
+                "INVALID_TICKET",
+                "No proxy ticket found for this HttpRequest object"
+            )
 
 class SessionTicket(models.Model):
     session = models.ForeignKey(Session, related_name="+", unique=True)

--- a/django_cas_ng/models.py
+++ b/django_cas_ng/models.py
@@ -43,7 +43,7 @@ class ProxyGrantingTicket(models.Model):
         session = Session.objects.get(session_key=request.session.session_key)
         try:
             pgt = cls.objects.get(user=request.user, session=session).pgt
-            params = urllib.urlencode({'pgt':pgt, 'targetService':service})
+            params = urllib.urlencode({'pgt': pgt, 'targetService': service})
             response = urllib2.urlopen(
                 "%s/proxy?%s" % (settings.CAS_SERVER_URL, params)
             )
@@ -51,13 +51,13 @@ class ProxyGrantingTicket(models.Model):
                 root = etree.fromstring(response.read())
                 tickets = root.xpath(
                     "//cas:proxyTicket",
-                    namespaces={"cas":"http://www.yale.edu/tp/cas"}
+                    namespaces={"cas": "http://www.yale.edu/tp/cas"}
                 )
                 if len(tickets) == 1:
                     return tickets[0].text
                 errors = root.xpath(
                     "//cas:authenticationFailure",
-                    namespaces={"cas":"http://www.yale.edu/tp/cas"}
+                    namespaces={"cas": "http://www.yale.edu/tp/cas"}
                 )
                 if len(errors) == 1:
                     raise ProxyError(errors[0].attrib['code'], errors[0].text)

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -8,6 +8,7 @@ from importlib import import_module
 from django.conf import settings
 from django.http import HttpResponseRedirect, HttpResponseForbidden
 from django.http import HttpResponse
+from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth import (
@@ -20,6 +21,7 @@ from django.contrib.sessions.models import Session
 
 
 from lxml import etree
+from datetime import timedelta
 
 from .models import ProxyGrantingTicket, SessionTicket
 
@@ -125,16 +127,35 @@ def login(request, next_page=None, required=False):
     service = _service_url(request, next_page)
     if ticket:
         user = authenticate(ticket=ticket, service=service, request=request)
+        pgtiou = request.session.get("pgtiou")
         if user is not None:
             auth_login(request, user)
             if not request.session.exists(request.session.session_key):
                 request.session.create()
+            session = Session.objects.get(
+                session_key=request.session.session_key
+            )
             SessionTicket.objects.create(
-                session=Session.objects.get(
-                    session_key=request.session.session_key
-                ),
+                session=session,
                 ticket=ticket
             )
+
+            if pgtiou and settings.CAS_PROXY_CALLBACK:
+                # Delete old PGT
+                ProxyGrantingTicket.objects.filter(
+                    user=user,
+                    session=session
+                ).delete()
+                # Set new PGT ticket
+                try:
+                    pgt = ProxyGrantingTicket.objects.get(pgtiou=pgtiou)
+                    pgt.user = user
+                    pgt.session = session
+                    pgt.save()
+                except ProxyGrantingTicket.DoesNotExist:
+                    pass
+                del request.session["pgtiou"]
+
             name = user.get_username()
             message = "Login succeeded. Welcome, %s." % name
             messages.success(request, message)
@@ -178,9 +199,10 @@ def callback(request):
     elif request.method == 'GET':
         pgtid = request.GET.get('pgtId')
         pgtiou = request.GET.get('pgtIou')
-        try:
-            pgt = ProxyGrantingTicket.objects.create(pgtiou=pgtiou, pgt=pgtid)
-            pgt.save()
-            return HttpResponse("ok\n", content_type="text/plain")
-        except ProxyGrantingTicket.DoesNotExist:
-            return HttpResponse("pgtIou not found\n", content_type="text/plain")
+        pgt = ProxyGrantingTicket.objects.create(pgtiou=pgtiou, pgt=pgtid)
+        pgt.save()
+        ProxyGrantingTicket.objects.filter(
+            session=None,
+            date__lt=(timezone.now() - timedelta(seconds=60))
+        ).delete()
+        return HttpResponse("ok\n", content_type="text/plain")


### PR DESCRIPTION
Storing PGT on a per session basis (instead of on a per user basis). This allow one user to be logged from multiple device without PGT overlapping each other.
Also add a method to retrieve easily a Proxy Ticket.