### PR TITLE
Fix logout redirection in SAML client

### DIFF
--- a/django_cas_ng/cas.py
+++ b/django_cas_ng/cas.py
@@ -347,4 +347,4 @@ class CASClientWithSAMLV1(CASClientBase):
             pass
 
     def _get_logout_redirect_parameter_name(self):
-        return 'url'
+        return 'service'


### PR DESCRIPTION
CASClientWithSAMLV1 extends CAS 3.0, not 2.0, so it should use the
"service" parameter, not "url".