### PR TITLE
Test against django 1.8, update dev requirements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ _build/
 
 # Tox
 .tox
+.cache/
+.coverage

--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -10,6 +10,7 @@ __all__ = []
 
 _DEFAULTS = {
     'CAS_ADMIN_PREFIX': None,
+    'CAS_CREATE_USER': True,
     'CAS_EXTRA_LOGIN_PARAMS': None,
     'CAS_RENEW': False,
     'CAS_IGNORE_REFERER': False,

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -30,8 +30,7 @@ class CASBackend(ModelBackend):
             created = False
         except User.DoesNotExist:
             # check if we want to create new users, if we don't fail auth
-            create = getattr(settings, 'CAS_CREATE_USER', True)
-            if not create:
+            if not settings.CAS_CREATE_USER:
                 return None
             # user will have an "unusable" password
             user = User.objects.create_user(username, '')

--- a/django_cas_ng/models.py
+++ b/django_cas_ng/models.py
@@ -57,8 +57,7 @@ class ProxyGrantingTicket(models.Model):
             try:
                 return client.get_proxy_ticket(pgt, service)
             except Exception as e:
-                raise
-                raise ProxyError(unicode(e))
+                raise ProxyError(str(e, 'utf-8'))
 
 
 class SessionTicket(models.Model):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
-tox==1.8.1
-pytest==2.6.4
-pytest-django==2.7.0
-pytest-pythonpath==0.3
+tox==2.1.1
+pytest==2.8.2
+pytest-cov==2.2.0
+pytest-django==2.9.1
+pytest-pythonpath==0.7
 lxml>=3.4

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -41,6 +41,39 @@ def test_backend_authentication_creating_a_user(monkeypatch, django_user_model):
     ).exists()
 
 
+def test_backend_authentication_do_not_create_user(monkeypatch, django_user_model, settings):
+    """
+    Test the case where CAS authentication is creating a new user.
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+    request.session = {}
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', {'ticket': ticket, 'service': service}, None
+
+    # we mock out the verify method so that we can bypass the external http
+    # calls needed for real authentication since we are testing the logic
+    # around authentication.
+    monkeypatch.setattr('django_cas_ng.cas.CASClientV2.verify_ticket', mock_verify)
+
+    # sanity check
+    assert not django_user_model.objects.filter(
+        username='test@example.com',
+    ).exists()
+
+    settings.CAS_CREATE_USER = False
+    backend = backends.CASBackend()
+    user = backend.authenticate(
+        ticket='fake-ticket', service='fake-service', request=request,
+    )
+
+    assert user is None
+    assert not django_user_model.objects.filter(
+        username='test@example.com',
+    ).exists()
+
+
 @pytest.mark.django_db
 def test_backend_for_existing_user(monkeypatch, django_user_model):
     """

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,52 @@
+"""Tests for the management commands"""
+from __future__ import absolute_import
+from django.conf import settings
+from django.core import management
+from importlib import import_module
+
+from django_cas_ng.models import SessionTicket, ProxyGrantingTicket
+
+import pytest
+
+SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
+
+
+@pytest.mark.django_db
+def test_command_clean_session(django_user_model):
+    # Use the configured session store to generate a fake session
+    session = SessionStore()
+    session['fake_session'] = 'fake-session'
+    session.save()
+    assert SessionStore(session_key=session.session_key) is not None
+
+    # Create a fake session ticket and make sure it exists in the db
+    session_ticket = SessionTicket.objects.create(
+        session_key=session.session_key,
+        ticket='fake-ticket'
+    )
+    assert session_ticket is not None
+    assert SessionTicket.objects.filter(session_key=session.session_key,
+                                        ticket='fake-ticket').exists() is True
+
+    # Create a fake user for the proxy granting ticket
+    user = django_user_model.objects.create(username='test-user', email='test@example.com')
+    assert user is not None
+    assert django_user_model.objects.filter(username='test-user').exists() is True
+
+    # Create a fake pgt
+    pgt = ProxyGrantingTicket.objects.create(session_key=session.session_key,
+                                       user=user, pgtiou='fake-ticket-iou',
+                                       pgt='fake-ticket')
+    assert pgt is not None
+    assert ProxyGrantingTicket.objects.filter(session_key=session.session_key,
+                                       user=user, pgtiou='fake-ticket-iou',
+                                       pgt='fake-ticket').exists() is True
+
+
+    # Call the clean sessions command and make sure things are cleaned up
+    management.call_command('django_cas_ng_clean_sessions')
+    assert SessionTicket.objects.filter(session_key=session.session_key,
+                                        ticket='fake-ticket').exists() is False
+    assert ProxyGrantingTicket.objects.filter(session_key=session.session_key,
+                                       user=user, pgtiou='fake-ticket-iou',
+                                       pgt='fake-ticket').exists() is False

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,355 @@
+from django.conf import settings
+from django.contrib.auth.middleware import AuthenticationMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory
+from importlib import import_module
+
+from django_cas_ng.models import SessionTicket, ProxyGrantingTicket
+from django_cas_ng.views import login, logout, callback
+
+import pytest
+
+SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
+
+
+# function takes a request and applies a middleware process
+def process_request_for_middleware(request, middleware):
+    middleware = middleware()
+    middleware.process_request(request)
+
+
+@pytest.mark.django_db
+def test_login_post_logout(django_user_model, settings):
+    """
+    Test that when CAS authentication creates a user, the signal is called with
+    `created = True`
+    """
+    settings.CAS_VERSION = 'CAS_2_SAML_1_0'
+
+    data = {'logoutRequest': '<samlp:LogoutRequest '
+                             'xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">'
+                             '<samlp:SessionIndex>fake-ticket'
+                             '</samlp:SessionIndex></samlp:LogoutRequest>'
+            }
+    session = SessionStore()
+    session['fake_session'] = 'fake-session'
+    session.save()
+    assert SessionStore(session_key=session.session_key) is not None
+
+    factory = RequestFactory()
+    request = factory.post('/login/', data)
+    request.session = session
+
+    # Create a fake session ticket and make sure it exists in the db
+    session_ticket = SessionTicket.objects.create(
+        session_key=session.session_key,
+        ticket='fake-ticket'
+    )
+    assert session_ticket is not None
+    assert SessionTicket.objects.filter(session_key=session.session_key,
+                                        ticket='fake-ticket').exists() is True
+    user = django_user_model.objects.create(username='test-user', email='test@example.com')
+    assert user is not None
+    assert django_user_model.objects.filter(username='test-user').exists() is True
+    request.user = user
+
+    # Create a fake pgt
+    pgt = ProxyGrantingTicket.objects.create(session_key=session.session_key,
+                                       user=user, pgtiou='fake-ticket-iou',
+                                       pgt='fake-ticket')
+    assert pgt is not None
+    assert ProxyGrantingTicket.objects.filter(session_key=session.session_key,
+                                       user=user, pgtiou='fake-ticket-iou',
+                                       pgt='fake-ticket').exists() is True
+
+    login(request)
+    assert SessionTicket.objects.filter(session_key=session.session_key,
+                                        ticket='fake-ticket').exists() is False
+    assert ProxyGrantingTicket.objects.filter(session_key=session.session_key,
+                                       user=user, pgtiou='fake-ticket-iou',
+                                       pgt='fake-ticket').exists() is False
+    assert SessionTicket.objects.filter(session_key=session.session_key,
+                                        ticket='fake-ticket').exists() is False
+
+
+@pytest.mark.django_db
+def test_login_authenticate_and_create_user(monkeypatch, django_user_model, settings):
+    """
+    Test the case where the login view authenticates a new user.
+    """
+    # No need to test the message framework
+    settings.CAS_LOGIN_MSG = None
+    # Make sure we use our backend
+    settings.AUTHENTICATION_BACKENDS = ['django_cas_ng.backends.CASBackend']
+    # Json serializer was havinga  hard time
+    settings.SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', {'ticket': ticket, 'service': service}, None
+    monkeypatch.setattr('django_cas_ng.cas.CASClientV2.verify_ticket', mock_verify)
+
+    factory = RequestFactory()
+    request = factory.get('/login/', {'ticket': 'fake-ticket',
+                                      'service': 'fake-service'})
+
+    # Create a session object from the middleware
+    process_request_for_middleware(request, SessionMiddleware)
+    # Create a user object from middleware
+    process_request_for_middleware(request, AuthenticationMiddleware)
+
+    response = login(request)
+    assert response.status_code == 302
+    assert django_user_model.objects.get(username='test@example.com').is_authenticated() is True
+
+
+@pytest.mark.django_db
+def test_login_authenticate_do_not_create_user(monkeypatch, django_user_model, settings):
+    """
+    Test the case where the login view authenticates a user, but does not
+    create a user based on the CAS_CREATE_USER setting.
+    """
+    # No need to test the message framework
+    settings.CAS_CREATE_USER = False
+    # No need to test the message framework
+    settings.CAS_LOGIN_MSG = None
+    # Make sure we use our backend
+    settings.AUTHENTICATION_BACKENDS = ['django_cas_ng.backends.CASBackend']
+    # Json serializer was havinga  hard time
+    settings.SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', {'ticket': ticket, 'service': service}, None
+    monkeypatch.setattr('django_cas_ng.cas.CASClientV2.verify_ticket', mock_verify)
+
+    factory = RequestFactory()
+    request = factory.get('/login/', {'ticket': 'fake-ticket',
+                                      'service': 'fake-service'})
+
+    # Create a session object from the middleware
+    process_request_for_middleware(request, SessionMiddleware)
+    # Create a user object from middleware
+    process_request_for_middleware(request, AuthenticationMiddleware)
+
+    response = login(request)
+    assert response.status_code == 403
+    assert django_user_model.objects.filter(username='test@example.com').exists() is False
+
+
+@pytest.mark.django_db
+def test_login_proxy_callback(monkeypatch, django_user_model, settings):
+    """
+    Test the case where the login view has a pgtiou.
+    """
+    # No need to test the message framework
+    settings.CAS_PROXY_CALLBACK = True
+    # No need to test the message framework
+    settings.CAS_LOGIN_MSG = None
+    # Make sure we use our backend
+    settings.AUTHENTICATION_BACKENDS = ['django_cas_ng.backends.CASBackend']
+    # Json serializer was havinga  hard time
+    settings.SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', {'ticket': ticket, 'service': service}, None
+    monkeypatch.setattr('django_cas_ng.cas.CASClientV2.verify_ticket', mock_verify)
+
+    factory = RequestFactory()
+    request = factory.get('/login/', {'ticket': 'fake-ticket',
+                                      'service': 'fake-service'})
+
+    # Create a session object from the middleware
+    process_request_for_middleware(request, SessionMiddleware)
+    # Create a user object from middleware
+    process_request_for_middleware(request, AuthenticationMiddleware)
+    request.session['pgtiou'] = 'fake-pgtiou'
+    request.session.save()
+
+    user = django_user_model.objects.create_user('test@example.com', '')
+    assert user is not None
+    pgt = ProxyGrantingTicket.objects.create(session_key=request.session.session_key,
+                                             user=user, pgtiou='fake-pgtiou',
+                                             pgt='fake-pgt')
+    assert pgt is not None
+
+    response = login(request)
+    assert response.status_code == 302
+    assert django_user_model.objects.get(username='test@example.com').is_authenticated() is True
+    assert ProxyGrantingTicket.objects.filter(pgtiou='fake-pgtiou').exists() is True
+    assert ProxyGrantingTicket.objects.filter(pgtiou='fake-pgtiou').count() == 1
+
+
+@pytest.mark.django_db
+def test_login_no_ticket():
+    """
+    Test the case where we try to login with no ticket
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+
+    # Create a session object from the middleware
+    process_request_for_middleware(request, SessionMiddleware)
+    # Create a user object from middleware
+    process_request_for_middleware(request, AuthenticationMiddleware)
+
+    response = login(request)
+    assert response.status_code == 302
+
+
+def test_login_put_not_allowed():
+    factory = RequestFactory()
+    request = factory.put('/login/')
+    response = login(request)
+    assert response.status_code == 405
+
+
+def test_login_delete_not_allowed():
+    factory = RequestFactory()
+    request = factory.delete('/login/')
+    response = login(request)
+    assert response.status_code == 405
+
+
+@pytest.mark.django_db
+def test_logout_not_completely(django_user_model, settings):
+    """
+    Test the case where the user logs out, without the logout_completely flag.
+    """
+    settings.CAS_LOGOUT_COMPLETELY = False
+
+    factory = RequestFactory()
+    request = factory.get('/logout/')
+    # Create a session object from the middleware
+    process_request_for_middleware(request, SessionMiddleware)
+
+    user = django_user_model.objects.create_user('test@example.com', '')
+    assert user is not None
+    request.user = user
+
+    response = logout(request)
+    assert response.status_code == 302
+    assert request.user.is_anonymous() is True
+
+
+@pytest.mark.django_db
+def test_logout_completely(django_user_model, settings):
+    """
+    Test the case where the user logs out.
+    """
+    settings.CAS_LOGOUT_COMPLETELY = True
+
+    factory = RequestFactory()
+    request = factory.get('/logout/')
+    # Create a session object from the middleware
+    process_request_for_middleware(request, SessionMiddleware)
+
+    user = django_user_model.objects.create_user('test@example.com', '')
+    assert user is not None
+    request.user = user
+
+    response = logout(request)
+    assert response.status_code == 302
+    assert request.user.is_anonymous() is True
+
+
+def test_logout_post_not_allowed():
+    factory = RequestFactory()
+    request = factory.post('/logout/')
+    response = logout(request)
+    assert response.status_code == 405
+
+
+def test_logout_put_not_allowed():
+    factory = RequestFactory()
+    request = factory.put('/logout/')
+    response = logout(request)
+    assert response.status_code == 405
+
+
+def test_logout_delete_not_allowed():
+    factory = RequestFactory()
+    request = factory.delete('/logout/')
+    response = logout(request)
+    assert response.status_code == 405
+
+
+@pytest.mark.django_db
+def test_callback_create_pgt():
+    """
+    Test the case where a pgt callback is used.
+    """
+    factory = RequestFactory()
+    request = factory.get('/callback/', {'pgtId': 'fake-pgtId',
+                                         'pgtIou': 'fake-pgtIou'})
+
+    response = callback(request)
+    assert response.status_code == 200
+    assert ProxyGrantingTicket.objects.filter(pgt='fake-pgtId',
+                                              pgtiou='fake-pgtIou'
+                                              ).exists() is True
+
+
+@pytest.mark.django_db
+def test_callback_post_logout(django_user_model, settings):
+    """
+    Test that when logout is from a callback
+    """
+    settings.CAS_VERSION = 'CAS_2_SAML_1_0'
+
+    data = {'logoutRequest': '<samlp:LogoutRequest '
+                             'xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">'
+                             '<samlp:SessionIndex>fake-ticket'
+                             '</samlp:SessionIndex></samlp:LogoutRequest>'
+            }
+    session = SessionStore()
+    session['fake_session'] = 'fake-session'
+    session.save()
+    assert SessionStore(session_key=session.session_key) is not None
+
+    factory = RequestFactory()
+    request = factory.post('/callback/', data)
+    request.session = session
+
+    # Create a fake session ticket and make sure it exists in the db
+    session_ticket = SessionTicket.objects.create(
+        session_key=session.session_key,
+        ticket='fake-ticket'
+    )
+    assert session_ticket is not None
+    assert SessionTicket.objects.filter(session_key=session.session_key,
+                                        ticket='fake-ticket').exists() is True
+    user = django_user_model.objects.create(username='test-user', email='test@example.com')
+    assert user is not None
+    assert django_user_model.objects.filter(username='test-user').exists() is True
+    request.user = user
+
+    # Create a fake pgt
+    pgt = ProxyGrantingTicket.objects.create(session_key=session.session_key,
+                                       user=user, pgtiou='fake-ticket-iou',
+                                       pgt='fake-ticket')
+    assert pgt is not None
+    assert ProxyGrantingTicket.objects.filter(session_key=session.session_key,
+                                       user=user, pgtiou='fake-ticket-iou',
+                                       pgt='fake-ticket').exists() is True
+
+    callback(request)
+    assert SessionTicket.objects.filter(session_key=session.session_key,
+                                        ticket='fake-ticket').exists() is False
+    assert ProxyGrantingTicket.objects.filter(session_key=session.session_key,
+                                       user=user, pgtiou='fake-ticket-iou',
+                                       pgt='fake-ticket').exists() is False
+    assert SessionTicket.objects.filter(session_key=session.session_key,
+                                        ticket='fake-ticket').exists() is False
+
+
+def test_callback_put_not_allowed():
+    factory = RequestFactory()
+    request = factory.put('/callback/')
+    response = callback(request)
+    assert response.status_code == 405
+
+
+def test_callback_delete_not_allowed():
+    factory = RequestFactory()
+    request = factory.delete('/callback/')
+    response = callback(request)
+    assert response.status_code == 405

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,11 @@ envlist=
     py27-django15,
     py27-django16,
     py27-django17,
+    py27-django18,
     py34-django15,
     py34-django16,
     py34-django17,
+    py34-django18,
     flake8,
 
 [flake8]
@@ -17,7 +19,7 @@ deps =
     -r{toxinidir}/requirements-dev.txt
 
 [testenv]
-commands=py.test --tb native {posargs:tests}
+commands=py.test --cov-report term-missing --cov django_cas_ng --tb native {posargs:tests}
 
 [testenv:py27-django15]
 basepython=python2.7
@@ -37,6 +39,12 @@ deps =
     Django>=1.7,<1.8
     {[base]deps}
 
+[testenv:py27-django18]
+basepython=python2.7
+deps =
+    Django>=1.8,<1.9
+    {[base]deps}
+
 [testenv:py34-django15]
 basepython=python3.4
 deps =
@@ -53,6 +61,12 @@ deps =
 basepython=python3.4
 deps =
     Django>=1.7,<1.8
+    {[base]deps}
+
+[testenv:py34-django18]
+basepython=python3.4
+deps =
+    Django>=1.8,<1.9
     {[base]deps}
 
 [testenv:flake8]


### PR DESCRIPTION
* Have tox create and test against django 1.8 with python 2 and python 3.
* Update the requirements-dev.txt file to use the latest versions of the testing packages. Add pytest-cov to allow pytest to generate a coverage report.
* Change the tox configuration to tell pytest to generate the coverage report.
* Add the .coverage and the .cache to the gitignore file.
* Create unit tests for views and management commands.
* Add a backend test to make sure that no users are created when CAS_CREATE_USER is false
* Fix a bug in the callback function where the slos were not being iterated over.