### PR TITLE
Let users know that django-cas-ng works with Django 1.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,7 @@ Features
 - Supports CAS_ versions 1.0, 2.0 and 3.0.
 - `Support Single Sign Out`_
 - Can fetch Proxy Granting Ticket
-- Supports Django 1.5, 1.6, 1.7 with `User custom model`_
-- Most probably it will work with Django 1.8 too (some of our developers use it
-  with this version), but we don't run automated tests to confirm that (yet).
+- Supports Django 1.5, 1.6, 1.7 and 1.8 with `User custom model`_
 - Supports Python 2.7, 3.x
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Topic :: Internet :: WWW/HTTP',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
     ],
     description='CAS 1.0/2.0 client authentication backend for Django (inherited from django-cas)',
     keywords=['django', 'cas', 'cas2', 'cas3', 'client', 'sso', 'single sign-on', 'authentication', 'auth'],


### PR DESCRIPTION
Add python and python3 to the setup file. This will allow other software to introspect that we support python3.