### PR TITLE
 Add a logout signal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,6 +207,25 @@ Sent on successful authentication, the ``CASBackend`` will fire the ``cas_user_a
   The service used to authenticate the user with the CAS.
 
 
+``django_cas_ng.signals.cas_user_logout``
+
+Sent on user logout. Will be fire over manual logout or logout via CAS SingleLogOut query.
+
+**Arguments sent with this signal**
+
+**sender**
+  ``manual`` if manual logout, ``slo`` on SingleLogOut
+
+**user**
+  The user instance that is logged out.
+
+**session**
+  The current session we are loging out.
+
+**ticket**
+  The ticket used to authenticate the user with the CAS. (if found, else valeu if set to ``None``)
+
+
 Proxy Granting Ticket
 ---------------------
 

--- a/django_cas_ng/models.py
+++ b/django_cas_ng/models.py
@@ -5,7 +5,7 @@ from .utils import (get_cas_client, get_service_url, get_user_from_session)
 
 
 from importlib import import_module
-
+from cas import CASError
 
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
@@ -55,8 +55,12 @@ class ProxyGrantingTicket(models.Model):
             client = get_cas_client(service_url=service_url)
             try:
                 return client.get_proxy_ticket(pgt, service)
+            # change CASError to ProxyError nicely
+            except CASError as error:
+                raise ProxyError(*error.args)
+            # juste embed other errors
             except Exception as e:
-                raise ProxyError(str(e, 'utf-8'))
+                raise ProxyError(e)
 
 
 class SessionTicket(models.Model):

--- a/django_cas_ng/signals.py
+++ b/django_cas_ng/signals.py
@@ -4,3 +4,7 @@ from django import dispatch
 cas_user_authenticated = dispatch.Signal(
     providing_args=['user', 'created', 'attributes', 'ticket', 'service'],
 )
+
+cas_user_logout = dispatch.Signal(
+    providing_args=['user', 'session', 'ticket'],
+)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,11 +1,103 @@
 from __future__ import absolute_import
 import pytest
 
+from django.conf import settings
 from django.test import RequestFactory
 from django.dispatch import receiver
+from importlib import import_module
 
+from django_cas_ng.models import SessionTicket
 from django_cas_ng.backends import CASBackend
-from django_cas_ng.signals import cas_user_authenticated
+from django_cas_ng.signals import cas_user_authenticated, cas_user_logout
+from django_cas_ng.views import login, logout
+
+
+SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
+
+
+@pytest.mark.django_db
+def test_signal_when_user_logout_manual(monkeypatch, django_user_model):
+    session = SessionStore()
+    session['fake_session_key'] = 'fake-session_value'
+    session.save()
+    assert SessionStore(session_key=session.session_key) is not None
+
+    factory = RequestFactory()
+    request = factory.get('/logout')
+    request.session = session
+
+    # Create a fake session ticket and make sure it exists in the db
+    session_ticket = SessionTicket.objects.create(
+        session_key=session.session_key,
+        ticket='fake-ticket'
+    )
+
+    user = django_user_model.objects.create_user('test@example.com', '')
+    assert user is not None
+    request.user = user
+
+    callback_values = {}
+
+    @receiver(cas_user_logout)
+    def callback(sender, session, **kwargs):
+        callback_values.update(kwargs)
+        callback_values['session'] = dict(session)
+
+    response = logout(request)
+    assert request.user.is_anonymous() is True
+    assert 'user' in callback_values
+    assert callback_values['user'] == user
+    assert 'session' in callback_values
+    assert callback_values['session'].get('fake_session_key') == 'fake-session_value'
+    assert 'ticket' in callback_values
+    assert callback_values['ticket'] == 'fake-ticket'
+
+
+@pytest.mark.django_db
+def test_signal_when_user_logout_slo(monkeypatch, django_user_model, settings):
+    data = {'logoutRequest': '<samlp:LogoutRequest '
+                             'xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">'
+                             '<samlp:SessionIndex>fake-ticket'
+                             '</samlp:SessionIndex></samlp:LogoutRequest>'
+           }
+
+    settings.CAS_VERSION = 'CAS_2_SAML_1_0'
+
+    factory = RequestFactory()
+    request = factory.post('/login', data)
+    # user session and current requests.session are different
+    request.session = {}
+
+    user = django_user_model.objects.create_user('test@example.com', '')
+    assert user is not None
+
+
+    session = SessionStore()
+    session['fake_session_key'] = 'fake-session_value'
+    session.save()
+    assert SessionStore(session_key=session.session_key) is not None
+
+    # Create a fake session ticket and make sure it exists in the db
+    session_ticket = SessionTicket.objects.create(
+        session_key=session.session_key,
+        ticket='fake-ticket'
+    )
+
+    callback_values = {}
+
+    @receiver(cas_user_logout)
+    def callback(sender, session, **kwargs):
+        callback_values.update(kwargs)
+        callback_values['session'] = dict(session)
+
+
+    response = login(request)
+    assert 'user' in callback_values
+    assert 'session' in callback_values
+    assert callback_values['session'].get('fake_session_key') == 'fake-session_value'
+    assert 'ticket' in callback_values
+    assert callback_values['ticket'] == 'fake-ticket'
+
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
 Add a logout signal fire on manual logout and SignLogOut request from CAS.
usefull for gracefully disconnect from some backends connected to via a ProxyTicket.