### PR TITLE
Bugfix for loop redirect when CAS_ADMIN_PREFIX is set as root

### DIFF
--- a/django_cas_ng/middleware.py
+++ b/django_cas_ng/middleware.py
@@ -39,6 +39,9 @@ class CASMiddleware(object):
         elif view_func == logout:
             return cas_logout(request, *view_args, **view_kwargs)
 
+        if view_func in (cas_login, cas_logout):
+            return None
+
         if settings.CAS_ADMIN_PREFIX:
             if not request.path.startswith(settings.CAS_ADMIN_PREFIX):
                 return None

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+from django.test import RequestFactory
+from django.contrib.auth.models import AnonymousUser
+
+from django_cas_ng.middleware import CASMiddleware
+from django_cas_ng import views
+
+
+def _process_view_with_middleware(
+        middleware_cls, url, view_func):
+    middleware = middleware_cls()
+    request_factory = RequestFactory()
+    request = request_factory.get(url)
+    request.user = AnonymousUser()
+    return middleware.process_view(request, view_func,
+                                   view_args=(), view_kwargs={})
+
+
+def test_root_as_cas_admin_prefix_with_cas_login(monkeypatch, settings):
+    monkeypatch.setattr('django_cas_ng.middleware.reverse',
+                        lambda func: "/login/")
+    settings.CAS_ADMIN_PREFIX = "/"
+    response = _process_view_with_middleware(
+        CASMiddleware, '/login/', views.login)
+    assert response is None
+
+
+def test_root_as_cas_admin_prefix_with_cas_logout(monkeypatch, settings):
+    monkeypatch.setattr('django_cas_ng.middleware.reverse',
+                        lambda func: "/login/")
+    settings.CAS_ADMIN_PREFIX = "/"
+    response = _process_view_with_middleware(
+        CASMiddleware, '/logout/', views.logout)
+    assert response is None


### PR DESCRIPTION
In my case my website's admin is in another sub domain, the whole site is under inspection so I set `CAS_ADMIN_PREFIX = "/"` to apply it to the whole site, but this will cause the loop redirection and below is how I fix it. let me know what do you think about it.