### PR TITLE
Login after the session is created, fix the need for double login

### DIFF
--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -60,9 +60,9 @@ def login(request, next_page=None, required=False):
                             request=request)
         pgtiou = request.session.get("pgtiou")
         if user is not None:
-            auth_login(request, user)
             if not request.session.exists(request.session.session_key):
                 request.session.create()
+            auth_login(request, user)
             SessionTicket.objects.create(
                 session_key=request.session.session_key,
                 ticket=ticket


### PR DESCRIPTION
The symptoms are the same as https://github.com/mingchen/django-cas-ng/issues/83 but I am not sure what is suggested here is still relevant.