### PR TITLE
delete django requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Django>=1.5
 lxml>=3.4
 
 # If you want the latest python-cas, uncomment following line.


### PR DESCRIPTION
Django 1.9 and 1.10 are not compatible. So when I use django 1.9 and reinstall requirements, I get conflicts. It would be better if django_cas_ng does not install its own version of django.