### PR TITLE
Update README.rst to include CAS_2_SAML_1_0 as valid version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Optional settings include:
   there is no referrer and no next page set. Default is ``/``.
 * ``CAS_RETRY_LOGIN``: If ``True`` and an unknown or invalid ticket is
   received, the user is redirected back to the login page.
-* ``CAS_VERSION``: The CAS protocol version to use. ``'1'`` ``'2'`` ``'3'`` and ``'``'CAS_2_SAML_1_0'``'`` are
+* ``CAS_VERSION``: The CAS protocol version to use. ``'1'`` ``'2'`` ``'3'`` and ``'CAS_2_SAML_1_0'`` are
   supported, with ``'2'`` being the default.
 * ``CAS_USERNAME_ATTRIBUTE``: The CAS user name attribute from response. The default is ``uid``.
 * ``CAS_PROXY_CALLBACK``: The full url to the callback view if you want to

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Optional settings include:
   there is no referrer and no next page set. Default is ``/``.
 * ``CAS_RETRY_LOGIN``: If ``True`` and an unknown or invalid ticket is
   received, the user is redirected back to the login page.
-* ``CAS_VERSION``: The CAS protocol version to use. ``'1'`` ``'2'`` and ``'3'`` are
+* ``CAS_VERSION``: The CAS protocol version to use. ``'1'`` ``'2'`` ``'3'`` and ``'``'CAS_2_SAML_1_0'``'`` are
   supported, with ``'2'`` being the default.
 * ``CAS_USERNAME_ATTRIBUTE``: The CAS user name attribute from response. The default is ``uid``.
 * ``CAS_PROXY_CALLBACK``: The full url to the callback view if you want to


### PR DESCRIPTION
Attributes delivered via SAML are only accessible when using this version in the configuration. ``'CAS_2_SAML_1_0'`` is not listed in any documentation as a valid version but was found in the test cases.