### PR TITLE
CAS_REDIRECT_URL should accept named URL patterns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,8 @@ Optional settings include:
 * ``CAS_LOGOUT_COMPLETELY``: If ``False``, logging out of the application
   won't log the user out of CAS as well.
 * ``CAS_REDIRECT_URL``: Where to send a user after logging in or out if
-  there is no referrer and no next page set. Default is ``/``.
+  there is no referrer and no next page set. This setting also accepts named
+  URL patterns. Default is ``/``.
 * ``CAS_RETRY_LOGIN``: If ``True`` and an unknown or invalid ticket is
   received, the user is redirected back to the login page.
 * ``CAS_VERSION``: The CAS protocol version to use. ``'1'`` ``'2'`` ``'3'`` and ``'CAS_2_SAML_1_0'`` are

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -3,6 +3,7 @@ from django.conf import settings as django_settings
 from django.contrib.auth import REDIRECT_FIELD_NAME, SESSION_KEY, BACKEND_SESSION_KEY, load_backend
 from django.contrib.auth.models import AnonymousUser
 from django.utils.six.moves import urllib_parse
+from django.shortcuts import resolve_url
 
 
 def get_protocol(request):
@@ -19,10 +20,11 @@ def get_redirect_url(request):
 
     next_ = request.GET.get(REDIRECT_FIELD_NAME)
     if not next_:
+        redirect_url = resolve_url(django_settings.CAS_REDIRECT_URL)
         if django_settings.CAS_IGNORE_REFERER:
-            next_ = django_settings.CAS_REDIRECT_URL
+            next_ = redirect_url
         else:
-            next_ = request.META.get('HTTP_REFERER', django_settings.CAS_REDIRECT_URL)
+            next_ = request.META.get('HTTP_REFERER', redirect_url)
         prefix = urllib_parse.urlunparse(
             (get_protocol(request), request.get_host(), '', '', '', ''),
         )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -19,3 +19,5 @@ DATABASES = {
         'ENGINE': 'django.db.backends.sqlite3',
     }
 }
+
+ROOT_URLCONF = 'tests.urls'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -108,3 +108,54 @@ def test_redirect_url_strips_domain_prefix(settings):
 
     assert actual == expected
 
+
+def test_redirect_url_named_pattern(settings):
+    settings.CAS_IGNORE_REFERER = False
+    settings.CAS_REDIRECT_URL = 'home'
+
+    factory = RequestFactory()
+    request = factory.get('/login/')
+
+    actual = get_redirect_url(request)
+    expected = '/'
+
+    assert actual == expected
+
+
+def test_redirect_url_named_pattern_without_referrer(settings):
+    settings.CAS_IGNORE_REFERER = True
+    settings.CAS_REDIRECT_URL = 'home'
+
+    factory = RequestFactory()
+    request = factory.get('/login/', HTTP_REFERER='/landing-page/')
+
+    actual = get_redirect_url(request)
+    expected = '/'
+
+    assert actual == expected
+
+
+def test_redirect_url_referrer_no_named_pattern(settings):
+    settings.CAS_IGNORE_REFERER = False
+    settings.CAS_REDIRECT_URL = '/wrong-landing-page/'
+
+    factory = RequestFactory()
+    request = factory.get('/login/', HTTP_REFERER='home')
+
+    actual = get_redirect_url(request)
+    expected = 'home'
+
+    assert actual == expected
+
+
+def test_redirect_url_next_no_named_pattern(settings):
+    settings.CAS_IGNORE_REFERER = False
+    settings.CAS_REDIRECT_URL = '/wrong-landing-page/'
+
+    factory = RequestFactory()
+    request = factory.get('/login/', data={'next': 'home'})
+
+    actual = get_redirect_url(request)
+    expected = 'home'
+
+    assert actual == expected

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+
+
+def dummy_view():
+    pass
+
+urlpatterns = [
+    url(r'^$', dummy_view, name="home"),
+]


### PR DESCRIPTION
Redirection URLs in Django such as [`LOGIN_REDIRECT_URL`](https://docs.djangoproject.com/en/dev/ref/settings/#login-redirect-url) or [`LOGOUT_REDIRECT_URL`](https://docs.djangoproject.com/en/dev/ref/settings/#logout-redirect-url) tend to accept named URL patterns to reduce configuration duplication. django-cas-ng's `CAS_REDIRECT_URL` should as well.

This would be especially useful in cases where django doesn't run at the root of the domain and where this would allow CAS login to easily benefit from django's automatic handling of `request.META['SCRIPT_NAME']`.