### PR TITLE
Make username normalization more generic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,10 +117,14 @@ Optional settings include:
 * ``CAS_USERNAME_ATTRIBUTE``: The CAS user name attribute from response. The default is ``uid``.
 * ``CAS_PROXY_CALLBACK``: The full url to the callback view if you want to
   retrive a Proxy Granting Ticket
-* ``CAS_FORCE_CHANGE_USERNAME_CASE``: If ``lower``, usernames returned from CAS are lowercased before
-  we check whether their account already exists. Allows user `Joe` to log in to CAS either as
-  `joe` or `JOE` without duplicate accounts being created by Django (since Django allows
-  case-sensitive duplicates). If ``upper``, the submitted username will be uppercased. Default is ``False``.
+* ``CAS_USERNAME_NORMALIZATIONS``: a list of normalization functions to apply
+  (in order) to usernames returned from CAS before we check whether their
+  account already exists. Valid normalizations are ``lower`` (lowercases the
+  username), ``upper`` (uppercases the usernames), ``strip`` (strips
+  whitespaces before and after the username) and any callable object.
+  Default is ``[]`` (no normalization is applied).
+* ``CAS_FORCE_CHANGE_USERNAME_CASE``: This setting is deprecated. Use
+  ``CAS_USERNAME_NORMALIZATIONS`` instead.
 
 Make sure your project knows how to log users in and out by adding these to
 your URL mappings::

--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -16,6 +16,7 @@ _DEFAULTS = {
     'CAS_IGNORE_REFERER': False,
     'CAS_LOGOUT_COMPLETELY': True,
     'CAS_FORCE_CHANGE_USERNAME_CASE': None,
+    'CAS_USERNAME_NORMALIZATIONS': [],
     'CAS_REDIRECT_URL': '/',
     'CAS_RETRY_LOGIN': False,
     'CAS_SERVER_URL': None,
@@ -34,3 +35,7 @@ for key, value in list(_DEFAULTS.items()):
     # Suppress errors from DJANGO_SETTINGS_MODULE not being set
     except ImportError:
         pass
+
+# Legacy setting
+if settings.CAS_FORCE_CHANGE_USERNAME_CASE in ['lower', 'upper']:
+    settings.CAS_USERNAME_NORMALIZATIONS.append(settings.CAS_FORCE_CHANGE_USERNAME_CASE)

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -26,11 +26,15 @@ class CASBackend(ModelBackend):
         if not username:
             return None
 
-        username_case = settings.CAS_FORCE_CHANGE_USERNAME_CASE
-        if username_case == 'lower':
-            username = username.lower()
-        elif username_case == 'upper':
-            username = username.upper()
+        for func in settings.CAS_USERNAME_NORMALIZATIONS:
+            if callable(func):
+                username = func(username)
+            elif func == 'lower':
+                username = username.lower()
+            elif func == 'upper':
+                username = username.upper()
+            elif func == 'strip':
+                username = username.strip()
 
         try:
             user = User.objects.get(**{User.USERNAME_FIELD: username})


### PR DESCRIPTION
Add a new `CAS_USERNAME_NORMALIZATIONS` settings that supercedes
`CAS_FORCE_CHANGE_USERNAME_CASE`. Improvements over
`CAS_FORCE_CHANGE_USERNAME_CASE` are:

 - `CAS_USERNAME_NORMALIZATIONS` supports an additional normalization,
   `"strip"`, that strips whitespaces before/after the username in addition to
   the existing `"lower"` and `"upper"` normalizations.
 - `CAS_USERNAME_NORMALIZATIONS` supports any Python callable as a
   normalization, allowing for maximum configurability and adaptability.
 - `CAS_USERNAME_NORMALIZATIONS` is a list, and thus supports easy chaining of
   multiple normalizations.