### PR TITLE
Make CASBackend more extensible

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,25 +185,48 @@ these ones:
             response['Location'] = url
         return response
 
-Additional Permissions
-----------------------
+Custom backends
+---------------
 
-The ``CASBackend`` object allows you to subclass and extend the user permissions
-check. This may be useful if you need to check if a user belongs to an
-organization that has permission to use your application. To use this feature
-you can create your own ``app/backends.py`` file, and within that file create
-your own backend class.
+The ``CASBackend`` class is heavily inspired from Django's own
+``RemoteUserBackend`` and allows for some configurability through subclassing
+if you need more control than django-cas-ng's settings provide. For instance,
+here is an example backend that only allows some users to login through CAS:
 
 ..  code-block:: python
 
     from django_cas_ng.backends import CASBackend
 
     class MyCASBackend(CASBackend):
-
         def user_can_authenticate(self, user):
             if user.has_permission('can_cas_login'):
                 return True
             return False
+
+If you need more control over the authentication mechanism of your project than
+django-cas-ng's settings provide, you can create your own authentication
+backend that inherits from ``django_cas_ng.backends.CASBackend`` and override
+these attributes or methods:
+
+**CASBackend.clean_username(username)**
+
+Performs any cleaning on the ``username`` prior to using it to get or create a
+``User`` object. Returns the cleaned username. The default implementations
+changes the case according to the value of ``CAS_FORCE_CHANGE_USERNAME_CASE``.
+
+**CASBackend.user_can_authenticate(user)**
+
+Returns whether the user is allowed to authenticate. For consistency with
+Django's own behavior, django-cas-ng will allow all users to authenticate
+through CAS on Django versions lower than 1.10; starting with Django 1.10
+however, django-cas-ng will prevent users with ``is_active=False`` from
+authenticating.
+
+**CASBackend.configure_user(user)**
+
+Configures a newly created user. This method is called immediately after a new
+user is created, and can be used to perform custom setup actions. Returns the
+user object.
 
 Signals
 -------

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -5,11 +5,10 @@ from __future__ import unicode_literals
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 from django_cas_ng.signals import cas_user_authenticated
 from .utils import get_cas_client
-
-User = get_user_model()
 
 __all__ = ['CASBackend']
 
@@ -23,26 +22,29 @@ class CASBackend(ModelBackend):
         username, attributes, pgtiou = client.verify_ticket(ticket)
         if attributes:
             request.session['attributes'] = attributes
+
         if not username:
             return None
+        user = None
+        username = self.clean_username(username)
 
-        username_case = settings.CAS_FORCE_CHANGE_USERNAME_CASE
-        if username_case == 'lower':
-            username = username.lower()
-        elif username_case == 'upper':
-            username = username.upper()
+        UserModel = get_user_model()
 
-        try:
-            user = User.objects.get(**{User.USERNAME_FIELD: username})
+        # Note that this could be accomplished in one try-except clause, but
+        # instead we use get_or_create when creating unknown users since it has
+        # built-in safeguards for multiple threads.
+        if settings.CAS_CREATE_USER:
+            user, created = UserModel._default_manager.get_or_create(**{
+                UserModel.USERNAME_FIELD: username
+            })
+            if created:
+                user = self.configure_user(user)
+        else:
             created = False
-        except User.DoesNotExist:
-            # check if we want to create new users, if we don't fail auth
-            if not settings.CAS_CREATE_USER:
-                return None
-            # user will have an "unusable" password
-            user = User.objects.create_user(username, '')
-            user.save()
-            created = True
+            try:
+                user = UserModel._default_manager.get_by_natural_key(username)
+            except UserModel.DoesNotExist:
+                pass
 
         if not self.user_can_authenticate(user):
             return None
@@ -61,13 +63,36 @@ class CASBackend(ModelBackend):
         )
         return user
 
-    def user_can_authenticate(self, user):
-        return True
+    # ModelBackend has a `user_can_authenticate` method starting from Django
+    # 1.10, that only allows active user to log in. For consistency,
+    # django-cas-ng will have the same behavior as Django's ModelBackend.
+    if not hasattr(ModelBackend, 'user_can_authenticate'):
+        def user_can_authenticate(self, user):
+            return True
 
-    def get_user(self, user_id):
-        """Retrieve the user's entry in the User model if it exists"""
+    def clean_username(self, username):
+        """
+        Performs any cleaning on the "username" prior to using it to get or
+        create the user object.  Returns the cleaned username.
 
-        try:
-            return User.objects.get(pk=user_id)
-        except User.DoesNotExist:
-            return None
+        By default, changes the username case according to
+        `settings.CAS_FORCE_CHANGE_USERNAME_CASE`.
+        """
+        username_case = settings.CAS_FORCE_CHANGE_USERNAME_CASE
+        if username_case == 'lower':
+            username = username.lower()
+        elif username_case == 'upper':
+            username = username.upper()
+        elif username_case is not None:
+            raise ImproperlyConfigured(
+                "Invalid value for the CAS_FORCE_CHANGE_USERNAME_CASE setting. "
+                "Valid values are `'lower'`, `'upper'`, and `None`.")
+        return username
+
+    def configure_user(self, user):
+        """
+        Configures a user after creation and returns the updated user.
+
+        By default, returns the user unmodified.
+        """
+        return user


### PR DESCRIPTION
Following Django's own `RemoteUserBackend`, add the two following hooks to the
`CASBackend` class:
 - `clean_username` allows to change the way usernames are normalized after CAS
   signin and before being linked to Django's User model
 - `configure_user` allows to perform additional actions (e.g. set the email)
   upon user creation through CAS

In addition, the authentication logic is slightly updated to match current
implementations of Djagno's RemoteUserBackend.