### PR TITLE
Change authenticate() argument order for changes in Django 1.11

### DIFF
--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -16,11 +16,11 @@ __all__ = ['CASBackend']
 class CASBackend(ModelBackend):
     """CAS authentication backend"""
 
-    def authenticate(self, ticket, service, request):
+    def authenticate(self, request, ticket, service):
         """Verifies CAS ticket and gets or creates User object"""
         client = get_cas_client(service_url=service)
         username, attributes, pgtiou = client.verify_ticket(ticket)
-        if attributes:
+        if attributes and request:
             request.session['attributes'] = attributes
 
         if not username:
@@ -49,7 +49,7 @@ class CASBackend(ModelBackend):
         if not self.user_can_authenticate(user):
             return None
 
-        if pgtiou and settings.CAS_PROXY_CALLBACK:
+        if pgtiou and settings.CAS_PROXY_CALLBACK and request:
             request.session['pgtiou'] = pgtiou
 
         # send the `cas_user_authenticated` signal


### PR DESCRIPTION
The old signature is deprecated. From Django 1.11 release notes: Support
for methods that don't accept request as the first positional argument
will be removed in Django 2.1.

request can also be None.