### PR TITLE
Fix issue #114 by adding CAS_STORE_NEXT setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,8 @@ Optional settings include:
   URL patterns. Default is ``/``.
 * ``CAS_RETRY_LOGIN``: If ``True`` and an unknown or invalid ticket is
   received, the user is redirected back to the login page.
+* ``CAS_STORE_NEXT``: If ``True``, the page to redirect to following login will be stored
+  as a session variable, which can avoid encoding errors depending on the CAS implementation.
 * ``CAS_VERSION``: The CAS protocol version to use. ``'1'`` ``'2'`` ``'3'`` and ``'CAS_2_SAML_1_0'`` are
   supported, with ``'2'`` being the default.
 * ``CAS_USERNAME_ATTRIBUTE``: The CAS user name attribute from response. The default is ``uid``.
@@ -389,3 +391,5 @@ References
 .. _Wojciech Rygielski: https://github.com/wrygiel
 .. _Valentin Samir: https://github.com/nitmir
 .. _Alexander Kavanaugh: https://github.com/kavdev
+.. _Daniel Davis: https://github.com/danizen
+

--- a/README.rst
+++ b/README.rst
@@ -358,6 +358,7 @@ Credits
 * `Wojciech Rygielski`_
 * `Valentin Samir`_
 * `Alexander Kavanaugh`_
+* `Daniel Davis`_
 
 References
 ----------

--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -24,6 +24,7 @@ _DEFAULTS = {
     'CAS_PROXY_CALLBACK': None,
     'CAS_LOGIN_MSG': _("Login succeeded. Welcome, %s."),
     'CAS_LOGGED_MSG': _("You are logged in as %s."),
+    'CAS_STORE_NEXT': False,
 }
 
 for key, value in list(_DEFAULTS.items()):

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -40,13 +40,14 @@ def get_service_url(request, redirect_to=None):
     service = urllib_parse.urlunparse(
         (protocol, host, request.path, '', '', ''),
     )
-    if '?' in service:
-        service += '&'
-    else:
-        service += '?'
-    service += urllib_parse.urlencode({
-        REDIRECT_FIELD_NAME: redirect_to or get_redirect_url(request)
-    })
+    if not django_settings.CAS_STORE_NEXT:
+        if '?' in service:
+            service += '&'
+        else:
+            service += '?'
+        service += urllib_parse.urlencode({
+            REDIRECT_FIELD_NAME: redirect_to or get_redirect_url(request)
+        })
     return service
 
 
@@ -64,7 +65,6 @@ def get_cas_client(service_url=None):
         username_attribute=django_settings.CAS_USERNAME_ATTRIBUTE,
         proxy_callback=django_settings.CAS_PROXY_CALLBACK
     )
-
 
 def get_user_from_session(session):
     try:

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -66,6 +66,7 @@ def get_cas_client(service_url=None):
         proxy_callback=django_settings.CAS_PROXY_CALLBACK
     )
 
+
 def get_user_from_session(session):
     try:
         user_id = session[SESSION_KEY]

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -41,6 +41,10 @@ def login(request, next_page=None, required=False):
     service_url = get_service_url(request, next_page)
     client = get_cas_client(service_url=service_url)
 
+    if not next_page and settings.CAS_STORE_NEXT and 'CASNEXT' in request.session:
+        next_page = request.session['CASNEXT']
+        del request.session['CASNEXT']
+
     if not next_page:
         next_page = get_redirect_url(request)
 
@@ -94,6 +98,8 @@ def login(request, next_page=None, required=False):
         else:
             raise PermissionDenied(_('Login failed.'))
     else:
+        if settings.CAS_STORE_NEXT:
+            request.session['CASNEXT'] = next_page
         return HttpResponseRedirect(client.get_login_url())
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,6 +44,17 @@ def test_service_url_preserves_query_parameters():
     assert 'next=https%3A%2F%2Ftestserver%2Flanding-page%2F' in actual
 
 
+def test_service_url_avoids_next(settings):
+    settings.CAS_STORE_NEXT = True
+
+    factory = RequestFactory()
+    request = factory.get('/login/')
+
+    actual = get_service_url(request, redirect_to='/admin/')
+    expected = 'http://testserver/login/'
+    assert actual == expected
+
+
 #
 # get_redirect_url tests
 #


### PR DESCRIPTION
- In presence of this setting, get_service_url does not include next parameter
- login view sets 'CASNEXT' in the session to the next_page when redirecting to CAS
- login view retrieves 'CASNEXT' from the session if next_page does not appear as a parameter, and then removes 'CASNEXT' from the session.
- May need to be able to provide a setting in future for the value of the session variable holding next.
