### PR TITLE
New settings option to apply attributes to User model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -396,4 +396,5 @@ References
 .. _Valentin Samir: https://github.com/nitmir
 .. _Alexander Kavanaugh: https://github.com/kavdev
 .. _Daniel Davis: https://github.com/danizen
+.. _Peter Baehr: https://github.com/pbaehr
 

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,10 @@ Optional settings include:
   we check whether their account already exists. Allows user `Joe` to log in to CAS either as
   `joe` or `JOE` without duplicate accounts being created by Django (since Django allows
   case-sensitive duplicates). If ``upper``, the submitted username will be uppercased. Default is ``False``.
+* ``CAS_APPLY_ATTRIBUTES_TO_USER``: If ``True`` any attributes returned by the CAS provider
+  included in the ticket will be applied to the User model returned by authentication. This is
+  useful if your provider is including details about the User which should be reflected in your model.
+  The default is ``False``.
 
 Make sure your project knows how to log users in and out by adding these to
 your URL mappings::
@@ -362,6 +366,7 @@ Credits
 * `Valentin Samir`_
 * `Alexander Kavanaugh`_
 * `Daniel Davis`_
+* `Peter Baehr`_
 
 References
 ----------

--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -25,6 +25,7 @@ _DEFAULTS = {
     'CAS_LOGIN_MSG': _("Login succeeded. Welcome, %s."),
     'CAS_LOGGED_MSG': _("You are logged in as %s."),
     'CAS_STORE_NEXT': False,
+    'CAS_APPLY_ATTRIBUTES_TO_USER': False,
 }
 
 for key, value in list(_DEFAULTS.items()):


### PR DESCRIPTION
It seems like this would be a convenient option for cases where the CAS provider sends additional information about a User in the attributes returned with the ticket.

If you are interested in merging this feature, please note there is some uncertainty in how to handle null values returned by the provider where our User Model does not allow for null. I solved it in the most logical way for my particular use case but there is some room for interpretation there depending on your philosophy.