### PR TITLE
Update middleware for consistency with new-style django middleware

### DIFF
--- a/django_cas_ng/middleware.py
+++ b/django_cas_ng/middleware.py
@@ -13,12 +13,18 @@ from django.contrib.auth.views import login, logout
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
+try:
+    # Django > 1.10 uses MiddlewareMixin
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
 from .views import login as cas_login, logout as cas_logout
 
 __all__ = ['CASMiddleware']
 
 
-class CASMiddleware(object):
+class CASMiddleware(MiddlewareMixin):
     """Middleware that allows CAS authentication on admin pages"""
 
     def process_request(self, request):


### PR DESCRIPTION
Currently broken on django 1.11 because of changes to middleware.  This change should allow middleware to work pre/post 1.11