### PR TITLE
Add the optional setting CAS_CREATE_USER_WITH_ID

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,10 @@ Optional settings include:
   see if it lives in ``django.contrib.admin.views``.
 * ``CAS_CREATE_USER``: Create a user when the CAS authentication is successful.
   The default is ``True``.
+* ``CAS_CREATE_USER_WITH_ID``: Create a user using the ``id`` field provided by
+  the attributes returned by the CAS provider. Default is ``False``. Raises
+  ``ImproperlyConfigured`` exception if attributes are not provided or do not
+  contain the field ``id``.
 * ``CAS_LOGIN_MSG``: Welcome message send via the messages framework upon
   successful authentication. Take the user login as formatting argument.
   The default is ``"Login succeeded. Welcome, %s."`` or some translation of it

--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -26,6 +26,7 @@ _DEFAULTS = {
     'CAS_LOGGED_MSG': _("You are logged in as %s."),
     'CAS_STORE_NEXT': False,
     'CAS_APPLY_ATTRIBUTES_TO_USER': False,
+    'CAS_CREATE_USER_WITH_ID': False
 }
 
 for key, value in list(_DEFAULTS.items()):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 
-import sys
-
 import pytest
 from django.test import RequestFactory
+from django.core.exceptions import ImproperlyConfigured
 
 from django_cas_ng import backends
+
 
 @pytest.mark.django_db
 def test_backend_authentication_creating_a_user(monkeypatch, django_user_model):
@@ -43,7 +43,7 @@ def test_backend_authentication_creating_a_user(monkeypatch, django_user_model):
 
 def test_backend_authentication_do_not_create_user(monkeypatch, django_user_model, settings):
     """
-    Test the case where CAS authentication is creating a new user.
+    Test the case where CAS authentication is not creating a new user.
     """
     factory = RequestFactory()
     request = factory.get('/login/')
@@ -104,7 +104,7 @@ def test_backend_for_existing_user(monkeypatch, django_user_model):
 
 
 @pytest.mark.django_db
-def test_backend_for_existing_user(monkeypatch, django_user_model):
+def test_backend_for_existing_user_no_request(monkeypatch, django_user_model):
     """
     Test the case where CAS authenticates an existing user, but request argument is None.
     """
@@ -243,6 +243,10 @@ def test_backend_applies_attributes_when_set(monkeypatch, settings):
 
 @pytest.mark.django_db
 def test_boolean_attributes_applied_as_booleans(monkeypatch, settings):
+    """
+    If CAS_CREATE_USER_WITH_ID is True and 'id' is in the attributes, use this
+    field to get_or_create a User.
+    """
     factory = RequestFactory()
     request = factory.get('/login/')
     request.session = {}
@@ -260,3 +264,125 @@ def test_boolean_attributes_applied_as_booleans(monkeypatch, settings):
     assert user is not None
     assert user.is_superuser is False
     assert user.is_staff is True
+
+
+@pytest.mark.django_db
+def test_backend_authentication_creates_a_user_with_id_attribute(monkeypatch, django_user_model, settings):
+    """
+    If CAS_CREATE_USER_WITH_ID is True and 'id' is in the attributes, use this
+    field to get_or_create a User.
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+    request.session = {}
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', {'id': 999, 'is_staff': True, 'is_superuser': False}, None
+
+    monkeypatch.setattr('cas.CASClientV2.verify_ticket', mock_verify)
+
+    # sanity check
+    assert not django_user_model.objects.filter(
+        username='test@example.com',
+    ).exists()
+
+    settings.CAS_CREATE_USER_WITH_ID = True
+    backend = backends.CASBackend()
+    user = backend.authenticate(
+        request, ticket='fake-ticket', service='fake-service',
+    )
+
+    assert user is not None
+    assert user.username == 'test@example.com'
+    assert django_user_model.objects.filter(id=999).exists()
+
+
+@pytest.mark.django_db
+def test_backend_authentication_create_user_with_id_and_user_exists(monkeypatch, django_user_model, settings):
+    """
+    If CAS_CREATE_USER_WITH_ID is True and and the User already exists, don't create another user.
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+    request.session = {}
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', {'id': 999, 'is_staff': True, 'is_superuser': False}, None
+
+    monkeypatch.setattr('cas.CASClientV2.verify_ticket', mock_verify)
+
+    existing_user = django_user_model.objects.create_user('test@example.com', '', id=999)
+
+    settings.CAS_CREATE_USER_WITH_ID = True
+    backend = backends.CASBackend()
+    user = backend.authenticate(
+        request, ticket='fake-ticket', service='fake-service',
+    )
+
+    assert django_user_model.objects.all().count() == 1
+    assert user is not None
+    assert user.username == 'test@example.com'
+    assert user.id == 999
+    assert user == existing_user
+
+
+@pytest.mark.django_db
+def test_backend_authentication_create_user_with_id_and_no_id_provided(monkeypatch, django_user_model, settings):
+    """
+    CAS_CREATE_USER_WITH_ID is True and the 'id' field is not in the attributes.
+
+    Should raise ImproperlyConfigured exception
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+    request.session = {}
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', {'is_staff': True, 'is_superuser': False}, None
+
+    monkeypatch.setattr('cas.CASClientV2.verify_ticket', mock_verify)
+
+    # sanity check
+    assert not django_user_model.objects.filter(
+        username='test@example.com',
+    ).exists()
+
+    settings.CAS_CREATE_USER_WITH_ID = True
+    backend = backends.CASBackend()
+    with pytest.raises(ImproperlyConfigured) as excinfo:
+        user = backend.authenticate(
+            request, ticket='fake-ticket', service='fake-service',
+        )
+
+    assert "CAS_CREATE_USER_WITH_ID is True, but `'id'` is not part of attributes." in str(excinfo)
+
+
+@pytest.mark.django_db
+def test_backend_authentication_create_user_with_id_and_attributes(monkeypatch, django_user_model, settings):
+    """
+    CAS_CREATE_USER_WITH_ID is True and the attributes are not provided.
+
+    Should raise ImproperlyConfigured exception
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+    request.session = {}
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', None, None
+
+    monkeypatch.setattr('cas.CASClientV2.verify_ticket', mock_verify)
+
+    # sanity check
+    assert not django_user_model.objects.filter(
+        username='test@example.com',
+    ).exists()
+
+    settings.CAS_CREATE_USER_WITH_ID = True
+    backend = backends.CASBackend()
+    with pytest.raises(ImproperlyConfigured) as excinfo:
+        user = backend.authenticate(
+            request, ticket='fake-ticket', service='fake-service',
+        )
+
+    assert "CAS_CREATE_USER_WITH_ID is True, but no attributes were provided" in str(excinfo)


### PR DESCRIPTION
We have a use case where we rely on the User ID in the CAS client to be kept in sync with the User ID in the CAS Provider Users table.

This pull request adds the optional setting CAS_CREATE_USER_WITH_ID so that Users will be created with the id provided by the CAS provider. This is so that User id's can be kept in sync between the CAS client and provider.

Note - There are some implications when toggling this option to `True` if your CAS client has already stored Users in the user table because the existing users will already have been created with the auto-assigned IDs. 