### PR TITLE
Allow relative CAS_SERVER_URL without protocol and hostname

### DIFF
--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -18,7 +18,7 @@ class CASBackend(ModelBackend):
 
     def authenticate(self, request, ticket, service):
         """Verifies CAS ticket and gets or creates User object"""
-        client = get_cas_client(service_url=service)
+        client = get_cas_client(service_url=service, request=request)
         username, attributes, pgtiou = client.verify_ticket(ticket)
         if attributes and request:
             request.session['attributes'] = attributes

--- a/django_cas_ng/models.py
+++ b/django_cas_ng/models.py
@@ -51,7 +51,7 @@ class ProxyGrantingTicket(models.Model):
                 "No proxy ticket found for this HttpRequest object"
             )
         else:
-            client = get_cas_client(service_url=service)
+            client = get_cas_client(service_url=service, request=request)
             try:
                 return client.get_proxy_ticket(pgt)
             # change CASError to ProxyError nicely

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -51,15 +51,21 @@ def get_service_url(request, redirect_to=None):
     return service
 
 
-def get_cas_client(service_url=None):
+def get_cas_client(service_url=None, request=None):
     """
     initializes the CASClient according to
     the CAS_* settigs
     """
+    # Handle CAS_SERVER_URL without protocol and hostname
+    server_url = django_settings.CAS_SERVER_URL
+    if request and server_url.startswith('/'):
+        scheme = request.META.get("X-Forwarded-Proto", request.scheme)
+        server_url = scheme + "://" + request.META['HTTP_HOST'] + server_url
+    assert server_url.startswith('http'), "settings.CAS_SERVER_URL invalid"
     return CASClient(
         service_url=service_url,
         version=django_settings.CAS_VERSION,
-        server_url=django_settings.CAS_SERVER_URL,
+        server_url=server_url,
         extra_login_params=django_settings.CAS_EXTRA_LOGIN_PARAMS,
         renew=django_settings.CAS_RENEW,
         username_attribute=django_settings.CAS_USERNAME_ATTRIBUTE,

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -58,7 +58,7 @@ def get_cas_client(service_url=None, request=None):
     """
     # Handle CAS_SERVER_URL without protocol and hostname
     server_url = django_settings.CAS_SERVER_URL
-    if request and server_url.startswith('/'):
+    if server_url and request and server_url.startswith('/'):
         scheme = request.META.get("X-Forwarded-Proto", request.scheme)
         server_url = scheme + "://" + request.META['HTTP_HOST'] + server_url
     assert server_url.startswith('http'), "settings.CAS_SERVER_URL invalid"

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -61,7 +61,7 @@ def get_cas_client(service_url=None, request=None):
     if server_url and request and server_url.startswith('/'):
         scheme = request.META.get("X-Forwarded-Proto", request.scheme)
         server_url = scheme + "://" + request.META['HTTP_HOST'] + server_url
-    #assert server_url.startswith('http'), "settings.CAS_SERVER_URL invalid"
+    # assert server_url.startswith('http'), "settings.CAS_SERVER_URL invalid"
     return CASClient(
         service_url=service_url,
         version=django_settings.CAS_VERSION,

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -61,7 +61,7 @@ def get_cas_client(service_url=None, request=None):
     if server_url and request and server_url.startswith('/'):
         scheme = request.META.get("X-Forwarded-Proto", request.scheme)
         server_url = scheme + "://" + request.META['HTTP_HOST'] + server_url
-    assert server_url.startswith('http'), "settings.CAS_SERVER_URL invalid"
+    #assert server_url.startswith('http'), "settings.CAS_SERVER_URL invalid"
     return CASClient(
         service_url=service_url,
         version=django_settings.CAS_VERSION,

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -39,7 +39,7 @@ __all__ = ['login', 'logout', 'callback']
 def login(request, next_page=None, required=False):
     """Forwards to CAS login URL or verifies CAS ticket"""
     service_url = get_service_url(request, next_page)
-    client = get_cas_client(service_url=service_url)
+    client = get_cas_client(service_url=service_url, request=request)
 
     if not next_page and settings.CAS_STORE_NEXT and 'CASNEXT' in request.session:
         next_page = request.session['CASNEXT']
@@ -130,7 +130,7 @@ def logout(request, next_page=None):
         redirect_url = urllib_parse.urlunparse(
             (protocol, host, next_page, '', '', ''),
         )
-        client = get_cas_client()
+        client = get_cas_client(request=request)
         return HttpResponseRedirect(client.get_logout_url(redirect_url))
     else:
         # This is in most cases pointless if not CAS_RENEW is set. The user will
@@ -143,7 +143,7 @@ def logout(request, next_page=None):
 def callback(request):
     """Read PGT and PGTIOU sent by CAS"""
     if request.method == 'POST' and request.POST.get('logoutRequest'):
-        clean_sessions(get_cas_client(), request)
+        clean_sessions(get_cas_client(request=request), request)
         return HttpResponse("{0}\n".format(_('ok')), content_type="text/plain")
     elif request.method == 'GET':
         pgtid = request.GET.get('pgtId')


### PR DESCRIPTION
I run multiple instances of the Django application and roll out updates rapidly by directing live traffic at my load-balancer. By allowing `settings.CAS_SERVER_URL` to be relative, the Django application can figure out the correct protocol (http/https) and hostname (e.g. test.example.com, live.example.com, etc.) on-the-fly based on HTTP request headers without the need for restarting the application. Furthermore, the same application can even serve multiple domain names.