### PR TITLE
Added bad_attributes_reject to check SAML key/value attributes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -238,6 +238,48 @@ Configures a newly created user. This method is called immediately after a new
 user is created, and can be used to perform custom setup actions. Returns the
 user object.
 
+**CASBackend.bad_attributes_reject(request, username, attributes)**
+
+Rejects a user if SAML username/attributes are not OK. For example, to accept a user belonging
+to departmentNumber 421 only, define in ``mysite/settings.py`` the key-value constant::
+
+    MY_SAML_CONTROL=('departmentNumber', '421')
+
+and the authentication backends::
+
+    AUTHENTICATION_BACKENDS = [
+        'django.contrib.auth.backends.ModelBackend',
+	'mysite.backends.MyCASBackend',
+    ]
+
+and create a file ``mysite/backends.py`` containing::
+
+    from django_cas_ng.backends import CASBackend
+    from django.contrib import messages
+    from django.conf import settings
+
+
+    class MyCASBackend(CASBackend):
+        def user_can_authenticate(self, user):
+            return True
+    
+    def bad_attributes_reject(self, request, username, attributes):
+        attribute = settings.MY_SAML_CONTROL[0]
+        value = settings.MY_SAML_CONTROL[1]
+        
+        if attribute not in attributes:
+	    message = 'No \''+ attribute + '\' in SAML attributes'
+	    messages.add_message(request, messages.ERROR, message)
+	    return message
+
+        if value not in attributes[attribute]:
+	    message = 'User ' + str(username) + ' is not in ' + value + ' ' + attribute + ', should be one of ' + str(attributes[attribute])
+            messages.add_message(request, messages.ERROR, message)
+            return message
+
+        return None
+
+
 Signals
 -------
 

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -28,6 +28,11 @@ class CASBackend(ModelBackend):
         user = None
         username = self.clean_username(username)
 
+        if attributes:
+            reject = self.bad_attributes_reject(request, username, attributes)
+            if reject:
+                return None
+
         UserModel = get_user_model()
 
         # Note that this could be accomplished in one try-except clause, but
@@ -152,3 +157,6 @@ class CASBackend(ModelBackend):
         By default, returns the user unmodified.
         """
         return user
+
+    def bad_attributes_reject(self, request, username, attributes):
+        return False


### PR DESCRIPTION
This pull request permits to limit the access using SAML attributes. An example is given to reject the user if its 'departmentNumber' is not '421'.