### PR TITLE
Add support for CAS attributes renaming

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,10 @@ Optional settings include:
   included in the ticket will be applied to the User model returned by authentication. This is
   useful if your provider is including details about the User which should be reflected in your model.
   The default is ``False``.
+* ``CAS_RENAME_ATTRIBUTES``: a dict used to rename the (key of the) attributes that the CAS server may retrun.
+  For example, if ``CAS_RENAME_ATTRIBUTES = {'ln':'last_name'}`` the ``ln`` attribute returned by the cas server
+  will be renamed as ``last_name``. Used with ``CAS_APPLY_ATTRIBUTES_TO_USER = True``, this provides an easy way 
+  to fill in Django Users' info independtly from the attributes' keys returned by the CAS server. 
 
 Make sure your project knows how to log users in and out by adding these to
 your URL mappings::

--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -26,7 +26,7 @@ _DEFAULTS = {
     'CAS_LOGGED_MSG': _("You are logged in as %s."),
     'CAS_STORE_NEXT': False,
     'CAS_APPLY_ATTRIBUTES_TO_USER': False,
-    'CAS_RENAME_ATTRIBUTES':{},
+    'CAS_RENAME_ATTRIBUTES': {},
     'CAS_CREATE_USER_WITH_ID': False
 }
 

--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -26,6 +26,7 @@ _DEFAULTS = {
     'CAS_LOGGED_MSG': _("You are logged in as %s."),
     'CAS_STORE_NEXT': False,
     'CAS_APPLY_ATTRIBUTES_TO_USER': False,
+    'CAS_RENAME_ATTRIBUTES':{},
     'CAS_CREATE_USER_WITH_ID': False
 }
 

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -33,6 +33,14 @@ class CASBackend(ModelBackend):
             if reject:
                 return None
 
+            # If we can, we rename the attributes as described in the settings file
+            # Existing attributes will be overwritten
+            for cas_attr_name, req_attr_name in settings.CAS_RENAME_ATTRIBUTES.items():
+                if cas_attr_name in attributes:
+                    attributes[req_attr_name] = attributes[cas_attr_name]
+                    attributes.pop(cas_attr_name)
+
+
         UserModel = get_user_model()
 
         # Note that this could be accomplished in one try-except clause, but

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -40,7 +40,6 @@ class CASBackend(ModelBackend):
                     attributes[req_attr_name] = attributes[cas_attr_name]
                     attributes.pop(cas_attr_name)
 
-
         UserModel = get_user_model()
 
         # Note that this could be accomplished in one try-except clause, but


### PR DESCRIPTION
This PR aims at solving #130.
It enables to rename the attributes returned by the CAS server. A simple use case is when you want to map the attributes returned by the CAS server to those used in the User model fields.

_As it is my first PR, I hope to have done it right._