### PR TITLE
Fix issue #160 and #135 - Django signals

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,8 +137,8 @@ Optional settings include:
   The default is ``False``.
 * ``CAS_RENAME_ATTRIBUTES``: a dict used to rename the (key of the) attributes that the CAS server may retrun.
   For example, if ``CAS_RENAME_ATTRIBUTES = {'ln':'last_name'}`` the ``ln`` attribute returned by the cas server
-  will be renamed as ``last_name``. Used with ``CAS_APPLY_ATTRIBUTES_TO_USER = True``, this provides an easy way 
-  to fill in Django Users' info independtly from the attributes' keys returned by the CAS server. 
+  will be renamed as ``last_name``. Used with ``CAS_APPLY_ATTRIBUTES_TO_USER = True``, this provides an easy way
+  to fill in Django Users' info independtly from the attributes' keys returned by the CAS server.
 
 Make sure your project knows how to log users in and out by adding these to
 your URL mappings::
@@ -269,11 +269,11 @@ and create a file ``mysite/backends.py`` containing::
     class MyCASBackend(CASBackend):
         def user_can_authenticate(self, user):
             return True
-    
+
     def bad_attributes_reject(self, request, username, attributes):
         attribute = settings.MY_SAML_CONTROL[0]
         value = settings.MY_SAML_CONTROL[1]
-        
+
         if attribute not in attributes:
 	    message = 'No \''+ attribute + '\' in SAML attributes'
 	    messages.add_message(request, messages.ERROR, message)
@@ -314,10 +314,36 @@ Sent on successful authentication, the ``CASBackend`` will fire the ``cas_user_a
 
 **service**
   The service used to authenticate the user with the CAS.
-  
+
 **request**
   The request that was used to login.
 
+
+django_cas_ng.signals.cas_user_cannot_authenticate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sent when CAS has verified the user, but the user cannot login.  Either the user does not exist and
+will not be created, or the user is not active.
+
+**Arguments sent with this signal**
+
+**sender**
+  The authentication backend instance that authenticated the user.
+
+**username**
+  The name of the user that cannot login
+
+**user**
+  The user instance that was found, but not authenticated.  Note that the user may be ``None``.
+
+**created**
+  Boolean as to whether the user was just created.
+
+**ticket**
+  The ticket used to authenticate the user with the CAS.
+
+**request**
+  The request that was used to login.
 
 django_cas_ng.signals.cas_user_logout
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -337,6 +363,9 @@ Sent on user logout. Will be fired over manual logout or logout via CAS SingleLo
 
 **ticket**
   The ticket used to authenticate the user with the CAS. (if found, else value if set to ``None``)
+
+**request**
+  The request that was used to logout.  Note that this may be ``None``.
 
 
 Proxy Granting Ticket

--- a/django_cas_ng/signals.py
+++ b/django_cas_ng/signals.py
@@ -5,6 +5,10 @@ cas_user_authenticated = dispatch.Signal(
     providing_args=['user', 'created', 'attributes', 'ticket', 'service', 'request'],
 )
 
+cas_user_cannot_authenticate = dispatch.Signal(
+    providing_args=['username', 'user', 'created', 'ticket', 'request'],
+)
+
 cas_user_logout = dispatch.Signal(
-    providing_args=['user', 'session', 'ticket'],
+    providing_args=['user', 'session', 'ticket', 'request'],
 )

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -134,6 +134,7 @@ def logout(request, next_page=None):
         user=request.user,
         session=request.session,
         ticket=ticket,
+        request=request,
     )
     auth_logout(request)
     # clean current session ProxyGrantingTicket and SessionTicket
@@ -184,6 +185,7 @@ def clean_sessions(client, request):
                 user=get_user_from_session(session),
                 session=session,
                 ticket=slo.text,
+                request=request,
             )
             session.flush()
             # clean logout session ProxyGrantingTicket and SessionTicket


### PR DESCRIPTION
- Issue #135 - add the `request` to the logout signal and to test
- Issue #160 - add a new `cas_user_cannot_authenticate` signal
    * Change semantics of `django_cas_ng.backends.CASBackend` so that
      `user_can_authenticate` method insists that the user exists,
      but still support Django 1.9
    * Call new signal handler when the user cannot authenticate.
    * Enhance `tests/test_signals.py` to check this new signal alongside
      existing signals.
    * Update `README.rst` to cover new signal handlers.