### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,8 +141,8 @@ Optional settings include:
   The default is ``False``.
 * ``CAS_RENAME_ATTRIBUTES``: a dict used to rename the (key of the) attributes that the CAS server may retrun.
   For example, if ``CAS_RENAME_ATTRIBUTES = {'ln':'last_name'}`` the ``ln`` attribute returned by the cas server
-  will be renamed as ``last_name``. Used with ``CAS_APPLY_ATTRIBUTES_TO_USER = True``, this provides an easy way 
-  to fill in Django Users' info independtly from the attributes' keys returned by the CAS server. 
+  will be renamed as ``last_name``. Used with ``CAS_APPLY_ATTRIBUTES_TO_USER = True``, this provides an easy way
+  to fill in Django Users' info independtly from the attributes' keys returned by the CAS server.
 * ``CAS_VERIFY_SSL_CERTIFICATE``: If ``False`` CAS server certificate won't be verified. This is useful when using a
   CAS test server with a self-signed certificate in a development environment. Default is ``True``.
 
@@ -288,11 +288,11 @@ and create a file ``mysite/backends.py`` containing:
     class MyCASBackend(CASBackend):
         def user_can_authenticate(self, user):
             return True
-    
+
         def bad_attributes_reject(self, request, username, attributes):
             attribute = settings.MY_ATTRIBUTE_CONTROL[0]
             value = settings.MY_ATTRIBUTE_CONTROL[1]
-        
+
             if attribute not in attributes:
                 message = 'No \''+ attribute + '\' in SAML attributes'
                 messages.add_message(request, messages.ERROR, message)
@@ -333,7 +333,7 @@ Sent on successful authentication, the ``CASBackend`` will fire the ``cas_user_a
 
 **service**
   The service used to authenticate the user with the CAS.
-  
+
 **request**
   The request that was used to login.
 
@@ -475,4 +475,3 @@ References
 .. _Alexander Kavanaugh: https://github.com/kavdev
 .. _Daniel Davis: https://github.com/danizen
 .. _Peter Baehr: https://github.com/pbaehr
-

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -123,5 +123,3 @@ creation in some case.
    * Support Django 1.5 custom user model.
 
 .. _commit history: https://github.com/mingchen/django-cas-ng/commits
-
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,4 +20,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/pypi.rst
+++ b/docs/pypi.rst
@@ -1,4 +1,3 @@
-
 Install from source::
 
     python setup install

--- a/docs/release-howto.rst
+++ b/docs/release-howto.rst
@@ -19,13 +19,13 @@ How To Make A Release
     make build
 
 7. Upload release to pypi.python.org
-    
+
     # update setuptools if needed.
     #pip install -U pip setuptools twine
 
-    python setup.py sdist upload    
+    python setup.py sdist upload
 
-    or 
+    or
 
     python setup.py sdist
     twine upload dist/django-cas-ng-3.5.9.tar.gz
@@ -41,4 +41,3 @@ Troubleshooting
     $ brew install gettext
     $ export PATH=$PATH:/usr/local/Cellar/gettext/0.19.8.1/bin
     $ make build
-

--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,3 @@ setup(
     install_requires=['python-cas>=1.2.0'],
     zip_safe=False,  # dot not package as egg or django will not found management commands
 )
-

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -274,7 +274,7 @@ def test_cas_attributes_renaming_working(monkeypatch, settings):
     assert session_attr['fn'] == 'MyFirstName'
     assert session_attr['last_name'] == 'MyLastName'
     with pytest.raises(KeyError):
-        session_attr['ln']  
+        session_attr['ln']
 
 
 @pytest.mark.django_db

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -8,4 +8,3 @@ from django_cas_ng.decorators import *
 def test_nothing_is_on_fire():
     # Nothing to do here, this file is used for testing import works.
     pass
-


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.