### PR TITLE
Distribute package as a universal wheel

### DIFF
--- a/docs/release-howto.rst
+++ b/docs/release-howto.rst
@@ -23,12 +23,12 @@ How To Make A Release
     # update setuptools if needed.
     #pip install -U pip setuptools twine
 
-    python setup.py sdist upload
+    python setup.py sdist bdist_wheel upload
 
     or
 
-    python setup.py sdist
-    twine upload dist/django-cas-ng-3.5.9.tar.gz
+    python setup.py sdist bdist_wheel
+    twine upload dist/django-cas-ng-3.5.9.tar.gz django_cas_ng-3.5.9-py2.py3-none-any.whl
 
 8. Create a new release on https://github.com/mingchen/django-cas-ng/releases
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE.txt


### PR DESCRIPTION
Wheels are the modern standard of Python distribution

Advantages of wheels:

- Faster installation
- Avoids arbitrary code execution for installation by avoiding setup.py
- Allows better caching for testing and continuous integration
- Creates .pyc files as part of installation to ensure they match the
  Python interpreter used
- More consistent installs across platforms

When you'd normally run `python3 setup.py sdist upload`, run instead
`python3 setup.py sdist bdist_wheel upload`.

For more details, see:

https://pythonwheels.com/