### PR TITLE
Remove unnecessary distutils fallback from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,7 @@
 
 from __future__ import absolute_import
 import codecs
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 with codecs.open('README.rst', encoding='utf-8') as f:
     readme = f.read()


### PR DESCRIPTION
Modern Python environment have setuptools. Can rely that it exists.