### PR TITLE
Simplify dependency handling in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,17 +12,16 @@ envlist=
 ignore = E402,E501
 exclude = tests/*
 
-[base]
-deps =
-    -r{toxinidir}/requirements-dev.txt
-
 [testenv]
 deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
-    {[base]deps}
+    pytest
+    pytest-cov
+    pytest-django
+    pytest-pythonpath
 commands=py.test --cov-report term-missing --cov django_cas_ng --tb native {posargs:tests}
 
 [testenv:flake8]


### PR DESCRIPTION
When tox runs, it installs the project and its dependencies. There is no
need to respecify the dependencies listed in setup.py in tox.ini. This
ensures that the dependencies listed in setup.py are correct and tests
pass when they are used.