### PR TITLE
Remove unused workarounds for EOL Django < 1.10

### DIFF
--- a/django_cas_ng/decorators.py
+++ b/django_cas_ng/decorators.py
@@ -11,8 +11,6 @@ from django.http import HttpResponseRedirect
 from django.core.exceptions import PermissionDenied
 from django.utils.http import urlquote
 
-import django
-
 __all__ = ['login_required', 'permission_required', 'user_passes_test']
 
 
@@ -29,14 +27,9 @@ def user_passes_test(test_func, login_url=None,
     def decorator(view_func):
         @wraps(view_func)
         def wrapper(request, *args, **kwargs):
-            if django.VERSION[0] < 2:
-                is_user_authenticated = request.user.is_authenticated()
-            else:
-                is_user_authenticated = request.user.is_authenticated
-
             if test_func(request.user):
                 return view_func(request, *args, **kwargs)
-            elif is_user_authenticated:
+            elif request.user.is_authenticated:
                 raise PermissionDenied
             else:
                 path = '%s?%s=%s' % (login_url, redirect_field_name,

--- a/django_cas_ng/middleware.py
+++ b/django_cas_ng/middleware.py
@@ -17,8 +17,6 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.deprecation import MiddlewareMixin
 
-import django
-
 from .views import (
     LoginView as cas_login,
     LogoutView as cas_logout
@@ -59,12 +57,7 @@ class CASMiddleware(MiddlewareMixin):
         elif not view_func.__module__.startswith('django.contrib.admin.'):
             return None
 
-        if django.VERSION[0] < 2:
-            is_user_authenticated = request.user.is_authenticated()
-        else:
-            is_user_authenticated = request.user.is_authenticated
-
-        if is_user_authenticated:
+        if request.user.is_authenticated:
             if request.user.is_staff:
                 return None
             else:

--- a/django_cas_ng/models.py
+++ b/django_cas_ng/models.py
@@ -7,8 +7,6 @@ from .utils import (get_cas_client, get_user_from_session)
 from importlib import import_module
 from cas import CASError
 
-import django
-
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 
@@ -36,12 +34,8 @@ class ProxyGrantingTicket(models.Model):
         for pgt in cls.objects.all():
             session = SessionStore(session_key=pgt.session_key)
             user = get_user_from_session(session)
-            if django.VERSION[0] < 2:
-                if not user.is_authenticated():
-                    pgt.delete()
-            else:
-                if not user.is_authenticated:
-                    pgt.delete()
+            if not user.is_authenticated:
+                pgt.delete()
 
     @classmethod
     def retrieve_pt(cls, request, service):
@@ -78,9 +72,5 @@ class SessionTicket(models.Model):
         for st in cls.objects.all():
             session = SessionStore(session_key=st.session_key)
             user = get_user_from_session(session)
-            if django.VERSION[0] < 2:
-                if not user.is_authenticated():
-                    st.delete()
-            else:
-                if not user.is_authenticated:
-                    st.delete()
+            if not user.is_authenticated:
+                st.delete()

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import sys
-import types
-
 from django.utils.decorators import method_decorator
 from django.utils.six.moves import urllib_parse
 from django.conf import settings
@@ -83,20 +80,7 @@ class LoginView(View):
         if not next_page:
             next_page = get_redirect_url(request)
 
-        # backward compability for django < 2.0
-        is_user_authenticated = False
-
-        if sys.version_info >= (3, 0):
-            bool_type = bool
-        else:
-            bool_type = types.BooleanType
-
-        if isinstance(request.user.is_authenticated, bool_type):
-            is_user_authenticated = request.user.is_authenticated
-        else:
-            is_user_authenticated = request.user.is_authenticated()
-
-        if is_user_authenticated:
+        if request.user.is_authenticated:
             if settings.CAS_LOGGED_MSG is not None:
                 message = settings.CAS_LOGGED_MSG % request.user.get_username()
                 messages.success(request, message)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,9 @@ Listed are the high-level, notable changes for each django-cas-ng release.
 Backwards incompatible changes or other upgrade issues are also described
 here. For additional detail, read the complete `commit history`_.
 
+**django-cas-ng UNRELEASED**
+
+  * Removed support for Django < 1.11.
 
 **django-cas-ng 3.5.10** ``[2018-10-09]``
 


### PR DESCRIPTION
`.is_authenticated()` and `.is_anonymous()` can always be used as a property.