### PR TITLE
fix bug where session_key is empty after logging in

### DIFF
--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -91,9 +91,9 @@ class LoginView(View):
                                 request=request)
             pgtiou = request.session.get("pgtiou")
             if user is not None:
+                auth_login(request, user)
                 if not request.session.exists(request.session.session_key):
                     request.session.create()
-                auth_login(request, user)
                 SessionTicket.objects.create(
                     session_key=request.session.session_key,
                     ticket=ticket


### PR DESCRIPTION
Logging in a user that already has a session can result in a flushed session (from django, for security reasons). In this case, the session will be deleted and no session_key will be present.
Then, trying to create a SessionTicket will fail because of the empty session key.