### PR TITLE
Add support for CAS response callbacks (fix #109)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,30 @@ Optional settings include:
   For example, if ``CAS_RENAME_ATTRIBUTES = {'ln':'last_name'}`` the ``ln`` attribute returned by the cas server
   will be renamed as ``last_name``. Used with ``CAS_APPLY_ATTRIBUTES_TO_USER = True``, this provides an easy way
   to fill in Django Users' info independtly from the attributes' keys returned by the CAS server.
+* ``CAS_RESPONSE_CALLBACKS``: a tuple consisting of paths to the callback functions. The functions will receive
+  a dict argument containing ``username``, ``attributes``, and ``pgtiou`` obtained from the response.
+  This is useful if you want to use the response data in your app, e.g. to save the attributes into a model.
+  Please note that if you use ``CAS_FORCE_CHANGE_USERNAME_CASE`` and/or ``CAS_RENAME_ATTRIBUTES``,
+  the response sent to the callback functions will also be altered.
+  Example::
+
+    CAS_RESPONSE_CALLBACKS = (
+        'my_app.callbacks.cas_callback',
+    )
+
+  In ``my_app/callbacks.py``:
+
+..  code-block:: python
+
+    def cas_callback(response):
+        username = response['username']
+        user, user_created = User.objects.get_or_create(username=username)
+        profile, created = user.get_profile()
+
+        profile.role = response['attributes']['role']
+        profile.birth_date = response['attributes']['birth_date']
+        profile.save()
+
 * ``CAS_VERIFY_SSL_CERTIFICATE``: If ``False`` CAS server certificate won't be verified. This is useful when using a
   CAS test server with a self-signed certificate in a development environment. Default is ``True``.
 

--- a/README.rst
+++ b/README.rst
@@ -465,6 +465,7 @@ Credits
 * `Alexander Kavanaugh`_
 * `Daniel Davis`_
 * `Peter Baehr`_
+* `laymonage`_
 
 References
 ----------
@@ -499,3 +500,4 @@ References
 .. _Alexander Kavanaugh: https://github.com/kavdev
 .. _Daniel Davis: https://github.com/danizen
 .. _Peter Baehr: https://github.com/pbaehr
+.. _laymonage: https://github.com/laymonage

--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -21,6 +21,7 @@ _DEFAULTS = {
     'CAS_VERSION': '2',
     'CAS_USERNAME_ATTRIBUTE': 'uid',
     'CAS_PROXY_CALLBACK': None,
+    'CAS_RESPONSE_CALLBACKS': None,
     'CAS_LOGIN_MSG': _("Login succeeded. Welcome, %s."),
     'CAS_LOGGED_MSG': _("You are logged in as %s."),
     'CAS_STORE_NEXT': False,

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -7,7 +7,7 @@ from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import ImproperlyConfigured
 from django_cas_ng.signals import cas_user_authenticated
 
-from .utils import get_cas_client
+from .utils import cas_response_callbacks, get_cas_client
 
 __all__ = ['CASBackend']
 
@@ -98,6 +98,16 @@ class CASBackend(ModelBackend):
             # instance in the DB.
             if settings.CAS_CREATE_USER:
                 user.save()
+
+        if settings.CAS_RESPONSE_CALLBACKS:
+            # Call the callback functions specified in the settings with
+            # CAS response as the argument.
+            response = {
+                'username': username,
+                'attributes': attributes,
+                'pgtiou': pgtiou
+            }
+            cas_response_callbacks(response)
 
         # send the `cas_user_authenticated` signal
         cas_user_authenticated.send(

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -1,4 +1,5 @@
 import warnings
+from importlib import import_module
 
 from cas import CASClient
 from django.conf import settings as django_settings
@@ -101,3 +102,16 @@ def get_user_from_session(session):
         return backend.get_user(user_id) or AnonymousUser()
     except KeyError:
         return AnonymousUser()
+
+
+def cas_response_callbacks(response):
+    """Call all callback functions with CAS response as an argument."""
+    callbacks = []
+    callbacks.extend(django_settings.CAS_RESPONSE_CALLBACKS)
+
+    for path in callbacks:
+        i = path.rfind('.')
+        module_name, function_name = path[:i], path[i + 1:]
+        module = import_module(module_name)
+        function = getattr(module, function_name)
+        function(response)


### PR DESCRIPTION
This PR aims at solving #109.
This enables the use of callback functions with the response data as an argument. We can then access the data in our app, including the additional attributes provided by the CAS server. A simple use case is when you want to save the attributes returned by the CAS server to a Django model, e.g. a [profile model](https://docs.djangoproject.com/en/2.1/topics/auth/customizing/#extending-the-existing-user-model).

The implementation is heavily inspired from a similar feature in [K-State's fork of `django-cas`](https://github.com/kstateome/django-cas#cas-response-callbacks). However, this one uses a simple Python `dict` with the existing data in the `authenticate` method, rather than an `ElementTree` object constructed from the raw xml response like in K-State's.