### PR TITLE
Add username and pgtiou to cas_user_authenticated signal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -446,6 +446,7 @@ Credits
 * `Alexander Kavanaugh`_
 * `Daniel Davis`_
 * `Peter Baehr`_
+* `laymonage`_
 
 References
 ----------
@@ -480,3 +481,4 @@ References
 .. _Alexander Kavanaugh: https://github.com/kavdev
 .. _Daniel Davis: https://github.com/danizen
 .. _Peter Baehr: https://github.com/pbaehr
+.. _laymonage: https://github.com/laymonage

--- a/README.rst
+++ b/README.rst
@@ -147,30 +147,6 @@ Optional settings include:
   For example, if ``CAS_RENAME_ATTRIBUTES = {'ln':'last_name'}`` the ``ln`` attribute returned by the cas server
   will be renamed as ``last_name``. Used with ``CAS_APPLY_ATTRIBUTES_TO_USER = True``, this provides an easy way
   to fill in Django Users' info independtly from the attributes' keys returned by the CAS server.
-* ``CAS_RESPONSE_CALLBACKS``: a tuple consisting of paths to the callback functions. The functions will receive
-  a dict argument containing ``username``, ``attributes``, and ``pgtiou`` obtained from the response.
-  This is useful if you want to use the response data in your app, e.g. to save the attributes into a model.
-  Please note that if you use ``CAS_FORCE_CHANGE_USERNAME_CASE`` and/or ``CAS_RENAME_ATTRIBUTES``,
-  the response sent to the callback functions will also be altered.
-  Example::
-
-    CAS_RESPONSE_CALLBACKS = (
-        'my_app.callbacks.cas_callback',
-    )
-
-  In ``my_app/callbacks.py``:
-
-..  code-block:: python
-
-    def cas_callback(response):
-        username = response['username']
-        user, user_created = User.objects.get_or_create(username=username)
-        profile, created = user.get_profile()
-
-        profile.role = response['attributes']['role']
-        profile.birth_date = response['attributes']['birth_date']
-        profile.save()
-
 * ``CAS_VERIFY_SSL_CERTIFICATE``: If ``False`` CAS server certificate won't be verified. This is useful when using a
   CAS test server with a self-signed certificate in a development environment. Default is ``True``.
 
@@ -470,7 +446,6 @@ Credits
 * `Alexander Kavanaugh`_
 * `Daniel Davis`_
 * `Peter Baehr`_
-* `laymonage`_
 
 References
 ----------
@@ -505,4 +480,3 @@ References
 .. _Alexander Kavanaugh: https://github.com/kavdev
 .. _Daniel Davis: https://github.com/danizen
 .. _Peter Baehr: https://github.com/pbaehr
-.. _laymonage: https://github.com/laymonage

--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -22,7 +22,6 @@ _DEFAULTS = {
     'CAS_VERSION': '2',
     'CAS_USERNAME_ATTRIBUTE': 'uid',
     'CAS_PROXY_CALLBACK': None,
-    'CAS_RESPONSE_CALLBACKS': None,
     'CAS_LOGIN_MSG': _("Login succeeded. Welcome, %s."),
     'CAS_LOGGED_MSG': _("You are logged in as %s."),
     'CAS_STORE_NEXT': False,

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -104,7 +104,9 @@ class CASBackend(ModelBackend):
             sender=self,
             user=user,
             created=created,
+            username=username,
             attributes=attributes,
+            pgtiou=pgtiou,
             ticket=ticket,
             service=service,
             request=request

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -7,7 +7,7 @@ from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import ImproperlyConfigured
 from django_cas_ng.signals import cas_user_authenticated
 
-from .utils import cas_response_callbacks, get_cas_client
+from .utils import get_cas_client
 
 __all__ = ['CASBackend']
 
@@ -98,16 +98,6 @@ class CASBackend(ModelBackend):
             # instance in the DB.
             if settings.CAS_CREATE_USER:
                 user.save()
-
-        if settings.CAS_RESPONSE_CALLBACKS:
-            # Call the callback functions specified in the settings with
-            # CAS response as the argument.
-            response = {
-                'username': username,
-                'attributes': attributes,
-                'pgtiou': pgtiou
-            }
-            cas_response_callbacks(response)
 
         # send the `cas_user_authenticated` signal
         cas_user_authenticated.send(

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -1,5 +1,4 @@
 import warnings
-from importlib import import_module
 
 from cas import CASClient
 from django.conf import settings as django_settings
@@ -102,16 +101,3 @@ def get_user_from_session(session):
         return backend.get_user(user_id) or AnonymousUser()
     except KeyError:
         return AnonymousUser()
-
-
-def cas_response_callbacks(response):
-    """Call all callback functions with CAS response as an argument."""
-    callbacks = []
-    callbacks.extend(django_settings.CAS_RESPONSE_CALLBACKS)
-
-    for path in callbacks:
-        i = path.rfind('.')
-        module_name, function_name = path[:i], path[i + 1:]
-        module = import_module(module_name)
-        function = getattr(module, function_name)
-        function(response)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -277,49 +277,6 @@ def test_cas_attributes_renaming_working(monkeypatch, settings):
 
 
 @pytest.mark.django_db
-def test_cas_response_callbacks_working(monkeypatch, settings):
-    """
-    Test to make sure the callback functions are run after a successful login.
-    """
-    factory = RequestFactory()
-    request = factory.get('/login/')
-    request.session = {}
-    data = {}
-
-    def mock_verify(ticket, service):
-        return 'test@example.com', {'role': 'student', 'birth_date': '1995-01-13'}, None
-
-    monkeypatch.setattr('cas.CASClientV2.verify_ticket', mock_verify)
-
-    def callback1(response):
-        data['role'] = response['attributes']['role']
-
-    def callback2(response):
-        data['birth_date'] = response['attributes']['birth_date']
-
-    settings.CAS_RESPONSE_CALLBACKS = (
-        'tests.test_backend.callback1',
-        'tests.test_backend.callback2'
-    )
-
-    globals()['callback1'] = None
-    globals()['callback2'] = None
-
-    monkeypatch.setattr('tests.test_backend.callback1', callback1)
-    monkeypatch.setattr('tests.test_backend.callback2', callback2)
-
-    backend = backends.CASBackend()
-    user = backend.authenticate(
-        request, ticket='fake-ticket', service='fake-service'
-    )
-
-    user.role, user.birth_date = data['role'], data['birth_date']
-
-    assert user.role == 'student'
-    assert user.birth_date == '1995-01-13'
-
-
-@pytest.mark.django_db
 def test_boolean_attributes_applied_as_booleans(monkeypatch, settings):
     """
     If CAS_CREATE_USER_WITH_ID is True and 'id' is in the attributes, use this


### PR DESCRIPTION
This may be useful if someone has set `CAS_CREATE_USER` to `False` but they want to obtain `username`.
Revert #196.