### PR TITLE
Fix 'CASClientV2' object has no attribute 'get_saml_slos' error.

### DIFF
--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -197,6 +197,8 @@ class CallbackView(View):
 
 
 def clean_sessions(client, request):
+    if not hasattr(client, 'get_saml_slos'):
+        return
     for slo in client.get_saml_slos(request.POST.get('logoutRequest')):
         try:
             st = SessionTicket.objects.get(ticket=slo.text)


### PR DESCRIPTION
Hello,

I have created this pull request to fix an issue I have with a CAS server using CAS v2.

The CAS server is:
`Apereo CAS version 4.1.7`

The complete traceback:
```
Traceback:

File "/usr/lib/python3/dist-packages/django/core/handlers/exception.py" in inner
  34.             response = get_response(request)

File "/usr/lib/python3/dist-packages/django/core/handlers/base.py" in _get_response
  126.                 response = self.process_exception_by_middleware(e, request)

File "/usr/lib/python3/dist-packages/django/core/handlers/base.py" in _get_response
  124.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/usr/lib/python3/dist-packages/django/views/generic/base.py" in view
  68.             return self.dispatch(request, *args, **kwargs)

File "/usr/lib/python3/dist-packages/django/utils/decorators.py" in _wrapper
  45.         return bound_method(*args, **kwargs)

File "/usr/lib/python3/dist-packages/django/views/decorators/csrf.py" in wrapped_view
  54.         return view_func(*args, **kwargs)

File "/usr/lib/python3/dist-packages/django_cas_ng/views.py" in dispatch
  39.         return super(LoginView, self).dispatch(request, *args, **kwargs)

File "/usr/lib/python3/dist-packages/django/views/generic/base.py" in dispatch
  88.         return handler(request, *args, **kwargs)

File "/usr/lib/python3/dist-packages/django_cas_ng/views.py" in post
  58.             clean_sessions(client, request)

File "/usr/lib/python3/dist-packages/django_cas_ng/views.py" in clean_sessions
  200.     for slo in client.get_saml_slos(request.POST.get('logoutRequest')):

Exception Type: AttributeError at /login/
Exception Value: 'CASClientV2' object has no attribute 'get_saml_slos'
Request information:
USER: AnonymousUser

GET:
next = '/'

POST:
logoutRequest = '<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="LR-66631-[...]" Version="2.0" IssueInstant="2019-03-03T21:09:43Z"><saml:NameID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">@NOT_USED@</saml:NameID><samlp:SessionIndex>[...]</samlp:SessionIndex></samlp:LogoutRequest>'

FILES: No FILES data

COOKIES: No cookie data
```

Settings:
```
CAS_SERVER_URL = 'https://[...]'
CAS_LOGOUT_COMPLETELY = True
CAS_FORCE_CHANGE_USERNAME_CASE = 'lower'
```

Regards