### PR TITLE
Issue/193 cas username attribute appears not to work

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,10 @@ Optional settings include:
 * ``CAS_VERSION``: The CAS protocol version to use. ``'1'`` ``'2'`` ``'3'`` and ``'CAS_2_SAML_1_0'`` are
   supported, with ``'2'`` being the default.
 * ``CAS_USERNAME_ATTRIBUTE``: The CAS user name attribute from response. The default is ``uid``.
+  If set with a value other than ``uid`` when ``CAS_VERSION`` is not ``'CAS_2_SAML_1_0'``, this
+  will be handled by the ``CASBackend``, in which case if the user lacks that attribute then
+  authentication will fail. Note that the attribute is checked before ``CAS_RENAME_ATTRIBUTES``
+  is applied.
 * ``CAS_PROXY_CALLBACK``: The full URL to the callback view if you want to
   retrive a Proxy Granting Ticket. Defaults is ``None``.
 * ``CAS_ROOT_PROXIED_AS``: Useful if behind a proxy server.  If host is listening on http://foo.bar:8080 but request

--- a/README.rst
+++ b/README.rst
@@ -486,6 +486,7 @@ Credits
 * `Daniel Davis`_
 * `Peter Baehr`_
 * `laymonage`_
+* `Michael Phelps`_
 
 References
 ----------
@@ -521,4 +522,5 @@ References
 .. _Daniel Davis: https://github.com/danizen
 .. _Peter Baehr: https://github.com/pbaehr
 .. _laymonage: https://github.com/laymonage
+.. _Michael Phelps: https://github.com/nottheswimmer
 .. _simplified URL routing syntax: https://docs.djangoproject.com/en/dev/releases/2.0/#simplified-url-routing-syntax

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -22,8 +22,11 @@ class CASBackend(ModelBackend):
         if attributes and request:
             request.session['attributes'] = attributes
 
-        if settings.CAS_USERNAME_ATTRIBUTE and settings.CAS_VERSION != 'CAS_2_SAML_1_0':
-            username = attributes[settings.CAS_USERNAME_ATTRIBUTE]
+        if settings.CAS_USERNAME_ATTRIBUTE != 'uid' and settings.CAS_VERSION != 'CAS_2_SAML_1_0':
+            if attributes:
+                username = attributes.get(settings.CAS_USERNAME_ATTRIBUTE)
+            else:
+                return None
 
         if not username:
             return None

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -22,6 +22,9 @@ class CASBackend(ModelBackend):
         if attributes and request:
             request.session['attributes'] = attributes
 
+        if settings.CAS_USERNAME_ATTRIBUTE and settings.CAS_VERSION != 'CAS_2_SAML_1_0':
+            username = attributes[settings.CAS_USERNAME_ATTRIBUTE]
+
         if not username:
             return None
         user = None

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Listed are the high-level, notable changes for each django-cas-ng release.
 Backwards incompatible changes or other upgrade issues are also described
 here. For additional detail, read the complete `commit history`_.
 
+**django-cas-ng x.x.x** ``[xxxx-xx-xx]``
+  * PR-206: New behavior for `CAS_USERNAME_ATTRIBUTE` setting which will now fallback to setting the specified attribute
+  for `username` when set with a value other than the default (`uid`) when using a `CAS_VERSION` that did not previously 
+  support this behavior (anything other than `CAS_VERSION = 'CAS_2_SAML_1_0`).
+
 **django-cas-ng 3.6.0** ``[2018-11-23]``
 
   * Removed support for Django < 1.11.

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -470,4 +470,3 @@ def test_backend_user_can_authenticate_with_cas_username_attribute(monkeypatch, 
     )
 
     assert user is None
-

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -433,7 +433,9 @@ def test_backend_user_can_authenticate_with_cas_username_attribute(monkeypatch, 
     request.session = {}
 
     settings.CAS_USERNAME_ATTRIBUTE = 'username'
+    settings.CAS_FORCE_CHANGE_USERNAME_CASE = 'upper'
 
+    # Testing to make sure the custom username attribute is handled correctly.
     def mock_verify(ticket, service):
         return 'bad@example.com', {'ticket': ticket, 'service': service, 'username': 'good@example.com'}, None
 
@@ -443,8 +445,9 @@ def test_backend_user_can_authenticate_with_cas_username_attribute(monkeypatch, 
         request, ticket='fake-ticket', service='fake-service',
     )
 
-    assert user.username == 'good@example.com'
+    assert user.username == 'GOOD@EXAMPLE.COM'
 
+    # Testing to make sure None is returned if username attribute is missing.
     def mock_verify(ticket, service):
         return 'bad@example.com', {'ticket': ticket, 'service': service}, None
 
@@ -455,3 +458,16 @@ def test_backend_user_can_authenticate_with_cas_username_attribute(monkeypatch, 
     )
 
     assert user is None
+
+    # Testing to make sure None is returned if attributes are None.
+    def mock_verify(ticket, service):
+        return 'bad@example.com', None, None
+
+    monkeypatch.setattr('cas.CASClientV2.verify_ticket', mock_verify)
+
+    user = backends.CASBackend().authenticate(
+        request, ticket='fake-ticket', service='fake-service',
+    )
+
+    assert user is None
+


### PR DESCRIPTION
There were a couple "gotchas" here:

1. Since the default is `uid`, a backwards incompatible change would have to be made to support that as a value for this new behavior.
2. Since ``CAS_VERSION = 'CAS_2_SAML_1_0'`` already has support for this, it should be excluded to not introduce any unintended behavior.

I'm not sure why there's a failing test, but it looks like it was happening to other commits too. I added tests with coverage for all my changes (and a little extra since I tested it with the `CAS_FORCE_CHANGE_USERNAME_CASE` attribute, which doesn't seem like it was tested anywhere else).