### PR TITLE
prevent creation of multiple SessionTickets with the same session_key

### DIFF
--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -94,10 +94,16 @@ class LoginView(View):
                 auth_login(request, user)
                 if not request.session.exists(request.session.session_key):
                     request.session.create()
-                SessionTicket.objects.create(
-                    session_key=request.session.session_key,
-                    ticket=ticket
-                )
+                    
+                try:
+                    st = SessionTicket.objects.get(session_key=request.session.session_key)
+                    st.ticket = ticket
+                    st.save()
+                except SessionTicket.DoesNotExist:
+                    SessionTicket.objects.create(
+                        session_key=request.session.session_key,
+                        ticket=ticket
+                    )
 
                 if pgtiou and settings.CAS_PROXY_CALLBACK:
                     # Delete old PGT

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -94,7 +94,7 @@ class LoginView(View):
                 auth_login(request, user)
                 if not request.session.exists(request.session.session_key):
                     request.session.create()
-                    
+
                 try:
                     st = SessionTicket.objects.get(session_key=request.session.session_key)
                     st.ticket = ticket


### PR DESCRIPTION
We have just started using django_cas_ng in production. Thanks to all for the work on it.

We are occasionally seeing multiple SessionTicket objects created with the same session_key, which is then causing an exception when they are fetched in LogoutView. I believe this is happening when our users do a CAS logout from another service, and then re-appear to do a new CAS login.

I believe this change will fix the problem. 