### PR TITLE
Make POST method of LoginView always return HttpResponse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,11 +239,11 @@ these ones:
 
     @csrf_exempt
     def login(request, **kwargs):
-        return _add_locale(request, baseviews.login(request, **kwargs))
+        return _add_locale(request, baseviews.LoginView.as_view()(request, **kwargs))
 
 
     def logout(request, **kwargs):
-        return _add_locale(request, baseviews.logout(request, **kwargs))
+        return _add_locale(request, baseviews.LoginView.as_view()(request, **kwargs))
 
 
     def _add_locale(request, response):

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -50,13 +50,15 @@ class LoginView(View):
         return HttpResponseRedirect(next_page)
 
     def post(self, request):
-        if request.POST.get('logoutRequest'):
-            next_page = request.POST.get('next', settings.CAS_REDIRECT_URL)
-            service_url = get_service_url(request, next_page)
-            client = get_cas_client(service_url=service_url, request=request)
+        next_page = request.POST.get('next', settings.CAS_REDIRECT_URL)
+        service_url = get_service_url(request, next_page)
+        client = get_cas_client(service_url=service_url, request=request)
 
+        if request.POST.get('logoutRequest'):
             clean_sessions(client, request)
             return HttpResponseRedirect(next_page)
+
+        return HttpResponseRedirect(client.get_login_url())
 
     def get(self, request):
         """


### PR DESCRIPTION
I'm not sure if this is the right fix, but the method should certainly not be returning `None` under any circumstance.

And now that the method is fixed, we can also update the docs to use CBV in the remaining example that was missing them.