### PR TITLE
Change deprecated 'syncdb' to 'migrate' in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,7 +222,7 @@ configured:
 Database
 ^^^^^^^^
 
-Run ``./manage.py syncdb`` to create Single Sign On and Proxy Granting Ticket tables.
+Run ``./manage.py syncdb`` (or ``./manage.py migrate`` for Django 1.7+) to create Single Sign On and Proxy Granting Ticket tables.
 On update you can just delete the ``django_cas_ng_sessionticket`` table and the
 ``django_cas_ng_proxygrantingticket`` before calling ``./manage.py syncdb``.
 


### PR DESCRIPTION
Thank you for your excellent work!
  
Since Django 1.7, `syncdb` has been [deprecated](https://docs.djangoproject.com/en/1.7/ref/django-admin/#syncdb) in favor of `migrate` and running `./manage.py syncdb` now yields `Unknown command: 'syncdb'` (which took me half an hour to figure out why). So maybe it will be better to state explicitly about this change  in README.rst ?