### PR TITLE
Django 3 compatibility

### DIFF
--- a/django_cas_ng/middleware.py
+++ b/django_cas_ng/middleware.py
@@ -9,12 +9,17 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.six.moves import urllib_parse
 from django.utils.translation import ugettext_lazy as _
 
 from .views import LoginView as cas_login, LogoutView as cas_logout
 
-__all__ = ['CASMiddleware']
+try:
+    from urllib import parse as urllib_parse
+except ImportError:
+    from django.utils.six.moves import urllib_parse
+
+
+__all__ = ["CASMiddleware"]
 
 
 class CASMiddleware(MiddlewareMixin):

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -10,7 +10,11 @@ from django.contrib.auth import (
 )
 from django.contrib.auth.models import AnonymousUser
 from django.shortcuts import resolve_url
-from django.utils.six.moves import urllib_parse
+
+try:
+    from urllib import parse as urllib_parse
+except ImportError:
+    from django.utils.six.moves import urllib_parse
 
 
 def get_protocol(request):

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -12,7 +12,6 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseRedirect
 from django.utils import timezone
 from django.utils.decorators import method_decorator
-from django.utils.six.moves import urllib_parse
 from django.utils.translation import ugettext_lazy as _
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
@@ -26,6 +25,11 @@ from .utils import (
     get_service_url,
     get_user_from_session,
 )
+
+try:
+    from urllib import parse as urllib_parse
+except ImportError:
+    from django.utils.six.moves import urllib_parse
 
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist=
     py{27,34,35,36}-django111
     py{34,35,36,37}-django20
     py{35,36,37}-django21
-    py{35,36,37}-djangomaster
+    py{36,37,38}-django30
+    py{36,37,38}-djangomaster
     flake8
 
 [flake8]
@@ -17,6 +18,7 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django30: Django>=3.0b1
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     pytest
     pytest-cov


### PR DESCRIPTION
Django 3 removes 'six' from django.utils.  urllib.parse can be
imported directly on python3.