### PR TITLE
Remove workaround for unsupported Django versions

### DIFF
--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -126,13 +126,6 @@ class CASBackend(ModelBackend):
         )
         return user
 
-    # ModelBackend has a `user_can_authenticate` method starting from Django
-    # 1.10, that only allows active user to log in. For consistency,
-    # django-cas-ng will have the same behavior as Django's ModelBackend.
-    if not hasattr(ModelBackend, 'user_can_authenticate'):
-        def user_can_authenticate(self, user):
-            return True
-
     def get_user_id(self, attributes):
         """
         For use when CAS_CREATE_USER_WITH_ID is True. Will raise ImproperlyConfigured


### PR DESCRIPTION
Django added ModelBackend.user_can_authenticate() in 1.10. This package
only has support for 2.0+.