### PR TITLE
Replace deprecated ugettext_lazy with gettext_lazy

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 __all__ = []
 

--- a/django_cas_ng/middleware.py
+++ b/django_cas_ng/middleware.py
@@ -11,7 +11,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .views import LoginView as cas_login, LogoutView as cas_logout
 

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -13,7 +13,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseRedirect
 from django.utils import timezone
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 


### PR DESCRIPTION
On Python 3, they are equivalent. Fixes deprecation warnings.