### PR TITLE
Update Travis configuration and test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,51 +1,47 @@
 language: python
-python:
-  - "3.5"
-env:
-  global:
-    - PIP_DOWNLOAD_CACHE=$HOME/.pip_cache
-
+cache: pip
 matrix:
   fast_finish: true
   include:
     - python: 3.5
-      env: TOX_ENV=py35-django20
+      env: TOXENV=py35-django20
     - python: 3.6
-      env: TOX_ENV=py36-django20
+      env: TOXENV=py36-django20
     - python: 3.7
-      env: TOX_ENV=py37-django20
-      dist: xenial
-      sudo: true
+      env: TOXENV=py37-django20
     - python: 3.5
-      env: TOX_ENV=py35-django21
+      env: TOXENV=py35-django21
     - python: 3.6
-      env: TOX_ENV=py36-django21
+      env: TOXENV=py36-django21
     - python: 3.7
-      env: TOX_ENV=py37-django21
-      dist: xenial
-      sudo: true
+      env: TOXENV=py37-django21
     - python: 3.5
-      env: TOX_ENV=py35-django22
+      env: TOXENV=py35-django22
     - python: 3.6
-      env: TOX_ENV=py36-djangomaster
+      env: TOXENV=py36-django22
     - python: 3.7
-      env: TOX_ENV=py37-djangomaster
-      dist: xenial
-      sudo: true
-    - env: TOX_ENV=flake8
-    - env: TOX_ENV=isort
+      env: TOXENV=py37-django22
+    - python: 3.8
+      env: TOXENV=py38-django22
+    - python: 3.6
+      env: TOXENV=py36-django30
+    - python: 3.7
+      env: TOXENV=py37-django30
+    - python: 3.8
+      env: TOXENV=py38-django30
+    - python: 3.6
+      env: TOXENV=py36-djangomaster
+    - python: 3.7
+      env: TOXENV=py37-djangomaster
+    - python: 3.8
+      env: TOXENV=py38-djangomaster
+    - env: TOXENV=flake8
+    - env: TOXENV=isort
   allow_failures:
-    - env: TOX_ENV=py35-djangomaster
-    - env: TOX_ENV=py36-djangomaster
-    - env: TOX_ENV=py37-djangomaster
-
-cache:
-  directories:
-    - $HOME/.pip-cache/
+    - env: TOXENV=py36-djangomaster
+    - env: TOXENV=py37-djangomaster
+    - env: TOXENV=py38-djangomaster
 install:
-  - "travis_retry pip install setuptools --upgrade"
-  - "pip install tox"
+  - pip install tox
 script:
-  - tox -e $TOX_ENV
-after_script:
-  - cat .tox/$TOX_ENV/log/*.log
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     py{35,36,37}-django20
     py{35,36,37}-django21
-    py{35,36,37}-django22
+    py{35,36,37,38}-django22
     py{36,37,38}-django30
     py{36,37,38}-djangomaster
     flake8


### PR DESCRIPTION
- Can drop sudo
- Can drop xenial (it is now the default)
- Use native pip caching support
- Test against Django 3.0
- Test against Python 3.8
- tox automatically checks the TOXENV environment variable
- No need to upgrade setuptools